### PR TITLE
Trace query service routes

### DIFF
--- a/cmd/query/app/handler.go
+++ b/cmd/query/app/handler.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
 
@@ -117,16 +117,16 @@ func NewAPIHandler(spanReader spanstore.Reader, dependencyReader dependencystore
 
 // RegisterRoutes registers routes for this handler on the given router
 func (aH *APIHandler) RegisterRoutes(router *mux.Router) {
-	router.HandleFunc(aH.route("/traces/{%s}", traceIDParam), aH.getTrace).Methods(http.MethodGet)
-	router.HandleFunc(aH.route("/archive/{%s}", traceIDParam), aH.getArchivedTrace).Methods(http.MethodGet)
-	router.HandleFunc(aH.route("/archive/{%s}", traceIDParam), aH.archiveTrace).Methods(http.MethodPost)
-	router.HandleFunc(aH.route(`/traces`), aH.search).Methods(http.MethodGet)
-	router.HandleFunc(aH.route(`/services`), aH.getServices).Methods(http.MethodGet)
+	aH.handleFunc(router, aH.getTrace, "/traces/{%s}", traceIDParam).Methods(http.MethodGet)
+	aH.handleFunc(router, aH.getArchivedTrace, "/archive/{%s}", traceIDParam).Methods(http.MethodGet)
+	aH.handleFunc(router, aH.archiveTrace, "/archive/{%s}", traceIDParam).Methods(http.MethodPost)
+	aH.handleFunc(router, aH.search, "/traces").Methods(http.MethodGet)
+	aH.handleFunc(router, aH.getServices, "/services").Methods(http.MethodGet)
 	// TODO change the UI to use this endpoint. Requires ?service= parameter.
-	router.HandleFunc(aH.route("/operations"), aH.getOperations).Methods(http.MethodGet)
+	aH.handleFunc(router, aH.getOperations, "/operations").Methods(http.MethodGet)
 	// TOOD - remove this when UI catches up
-	router.HandleFunc(aH.route("/services/{%s}/operations", serviceParam), aH.getOperationsLegacy).Methods(http.MethodGet)
-	router.HandleFunc(aH.route("/dependencies"), aH.dependencies).Methods(http.MethodGet)
+	aH.handleFunc(router, aH.getOperationsLegacy, "/services/{%s}/operations", serviceParam).Methods(http.MethodGet)
+	aH.handleFunc(router, aH.dependencies, "/dependencies").Methods(http.MethodGet)
 }
 
 func (aH *APIHandler) handleFunc(

--- a/cmd/query/app/handler_test.go
+++ b/cmd/query/app/handler_test.go
@@ -145,9 +145,9 @@ func TestTracing(t *testing.T) {
 	defer opentracing.InitGlobalTracer(globalTracer)
 
 	reporter := jaeger.NewInMemoryReporter()
-	jaeger, jaegerCloser := jaeger.NewTracer("test", jaeger.NewConstSampler(true), reporter)
+	jaegerTracer, jaegerCloser := jaeger.NewTracer("test", jaeger.NewConstSampler(true), reporter)
 	defer jaegerCloser.Close()
-	opentracing.InitGlobalTracer(jaeger)
+	opentracing.InitGlobalTracer(jaegerTracer)
 
 	server, readMock, _ := initializeTestServer()
 	defer server.Close()
@@ -160,7 +160,7 @@ func TestTracing(t *testing.T) {
 	assert.Len(t, response.Errors, 0)
 
 	assert.Len(t, reporter.GetSpans(), 1)
-	// assert.Equal(t, "/traces/{traceID}", reporter.GetSpans()[0])
+	assert.Equal(t, "/api/traces/{traceID}", reporter.GetSpans()[0].(*jaeger.Span).OperationName())
 }
 
 func TestGetTraceDBFailure(t *testing.T) {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 58c57d356d0af8d48c3a75adb711d86239720fc846a4e26fee2e6304f7408328
-updated: 2017-03-18T20:52:33.113387-04:00
+hash: bde020ba2adb372666e31edaa6527e35f4c9264db484280dc80201058468fc8d
+updated: 2017-03-19T14:13:43.080135494-04:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -36,6 +36,10 @@ imports:
   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
 - name: github.com/kr/pretty
   version: cfb55aafdaf3ec08f0db22699ab822c50091b1c4
+- name: github.com/opentracing-contrib/go-stdlib
+  version: 1de4cc2120e71f745a5810488bf64b29b6d7d9f6
+  subpackages:
+  - nethttp
 - name: github.com/opentracing/opentracing-go
   version: 0c3154a3c2ce79d3271985848659870599dfb77c
   subpackages:
@@ -59,6 +63,8 @@ imports:
   version: 0c9e689d64f004564b79d9a663634756df322902
 - name: github.com/uber-go/zap
   version: c4939d1166b2220bb45338e21506623b4bbdec50
+- name: github.com/uber/jaeger-client-go
+  version: 81280be4110ac49c4c2094eeffd409a0043d51c0
 - name: github.com/uber/jaeger-lib
   version: b9556711760c45a30bd79c31c8f041d0d9aba997
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -64,7 +64,7 @@ imports:
 - name: github.com/uber-go/zap
   version: c4939d1166b2220bb45338e21506623b4bbdec50
 - name: github.com/uber/jaeger-client-go
-  version: 81280be4110ac49c4c2094eeffd409a0043d51c0
+  version: 6897a8cdc88b22a5bdecf563c246a6275b44c92a
 - name: github.com/uber/jaeger-lib
   version: b9556711760c45a30bd79c31c8f041d0d9aba997
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,3 +27,8 @@ import:
   subpackages:
   - assert
   - mock
+- package: github.com/opentracing-contrib/go-stdlib
+  subpackages:
+  - nethttp
+- package: github.com/uber/jaeger-client-go
+  version: ^2.2.1


### PR DESCRIPTION
TODO:
  * [ ] upgrade to released version of jaeger-client (currently using SHA from https://github.com/uber/jaeger-client-go/pull/117)