### PR TITLE
Make agent hostPort more docker friendly

### DIFF
--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -48,7 +48,7 @@ const (
 	defaultServerWorkers = 10
 	defaultMinPeers      = 3
 
-	defaultSamplingServerHostPort = "localhost:5778"
+	defaultSamplingServerHostPort = ":5778"
 
 	agentServiceName            = "jaeger-agent"
 	defaultCollectorServiceName = "jaeger-collector"
@@ -104,7 +104,7 @@ func NewBuilder() *Builder {
 				Server: ServerConfiguration{
 					QueueSize:     defaultQueueSize,
 					MaxPacketSize: defaultMaxPacketSize,
-					HostPort:      "127.0.0.1:5775",
+					HostPort:      ":5775",
 				},
 			},
 			{
@@ -114,7 +114,7 @@ func NewBuilder() *Builder {
 				Server: ServerConfiguration{
 					QueueSize:     defaultQueueSize,
 					MaxPacketSize: defaultMaxPacketSize,
-					HostPort:      "127.0.0.1:6831",
+					HostPort:      ":6831",
 				},
 			},
 			{
@@ -124,12 +124,12 @@ func NewBuilder() *Builder {
 				Server: ServerConfiguration{
 					QueueSize:     defaultQueueSize,
 					MaxPacketSize: defaultMaxPacketSize,
-					HostPort:      "127.0.0.1:6832",
+					HostPort:      ":6832",
 				},
 			},
 		},
 		SamplingServer: SamplingServerConfiguration{
-			HostPort: "127.0.0.1:5778",
+			HostPort: ":5778",
 		},
 	}
 }


### PR DESCRIPTION
For localhost to hit agent processor endpoints in the docker world, we need to use 0.0.0.0 as the host for the agent.