### PR TITLE
Fixes #104 - Individual modules are now started like the standalone.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,8 @@ Gemfile.lock
 vendor/
 jaeger-ui-build/
 examples/hotrod/hotrod*
+cmd/agent/jaeger-agent*
+cmd/collector/jaeger-collector*
+cmd/query/jaeger-query*
+cmd/standalone/jaeger-standalone*
 cmd/standalone/standalone*

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,11 @@ build_ui:
 build-all-in-one-linux: build_ui
 	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/standalone/standalone-linux ./cmd/standalone/main.go
 
+build-single-modules:
+	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/agent/jaeger-agent-linux ./cmd/agent/main.go
+	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/collector/jaeger-collector-linux ./cmd/collector/main.go
+	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./cmd/query/jaeger-query-linux ./cmd/query/main.go
+
 .PHONY: cover
 cover:
 	./scripts/cover.sh $(shell go list $(PACKAGES))

--- a/cmd/collector/starter/starter.go
+++ b/cmd/collector/starter/starter.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package starter
+
+import (
+	"net"
+	"strconv"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/thrift"
+	"go.uber.org/zap"
+
+	"github.com/uber/jaeger-lib/metrics"
+	basic "github.com/uber/jaeger/cmd/builder"
+	collector "github.com/uber/jaeger/cmd/collector/app/builder"
+	"github.com/uber/jaeger/storage/spanstore/memory"
+	jc "github.com/uber/jaeger/thrift-gen/jaeger"
+	zc "github.com/uber/jaeger/thrift-gen/zipkincore"
+)
+
+const (
+	serviceName = "jaeger-collector"
+)
+
+// StartCollector starts a new collector service, based on the given parameters.
+func StartCollector(logger *zap.Logger, baseFactory metrics.Factory, memoryStore *memory.Store) {
+	metricsFactory := baseFactory.Namespace(serviceName, nil)
+
+	spanBuilder, err := collector.NewSpanHandlerBuilder(
+		basic.Options.LoggerOption(logger),
+		basic.Options.MetricsFactoryOption(metricsFactory),
+		basic.Options.MemoryStoreOption(memoryStore),
+	)
+	if err != nil {
+		logger.Fatal("Unable to set up builder", zap.Error(err))
+	}
+	zipkinSpansHandler, jaegerBatchesHandler, err := spanBuilder.BuildHandlers()
+	if err != nil {
+		logger.Fatal("Unable to build span handlers", zap.Error(err))
+	}
+
+	ch, err := tchannel.NewChannel("jaeger-collector", &tchannel.ChannelOptions{})
+	if err != nil {
+		logger.Fatal("Unable to create new TChannel", zap.Error(err))
+	}
+	server := thrift.NewServer(ch)
+	server.Register(jc.NewTChanCollectorServer(jaegerBatchesHandler))
+	server.Register(zc.NewTChanZipkinCollectorServer(zipkinSpansHandler))
+	portStr := ":" + strconv.Itoa(*collector.CollectorPort)
+	listener, err := net.Listen("tcp", portStr)
+	if err != nil {
+		logger.Fatal("Unabled to start listening on channel", zap.Error(err))
+	}
+	ch.Serve(listener)
+	logger.Info("Starting jaeger-collector TChannel server", zap.Int("port", *collector.CollectorPort))
+}

--- a/cmd/query/starter/starter.go
+++ b/cmd/query/starter/starter.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package starter
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"go.uber.org/zap"
+
+	"github.com/uber/jaeger-lib/metrics"
+	basic "github.com/uber/jaeger/cmd/builder"
+	queryApp "github.com/uber/jaeger/cmd/query/app"
+	query "github.com/uber/jaeger/cmd/query/app/builder"
+	"github.com/uber/jaeger/pkg/recoveryhandler"
+	"github.com/uber/jaeger/storage/spanstore/memory"
+)
+
+// StartQuery starts a new query service, based on the given parameters.
+func StartQuery(logger *zap.Logger, baseFactory metrics.Factory, memoryStore *memory.Store) {
+	metricsFactory := baseFactory.Namespace("jaeger-query", nil)
+
+	storageBuild, err := query.NewStorageBuilder(
+		basic.Options.LoggerOption(logger),
+		basic.Options.MetricsFactoryOption(metricsFactory),
+		basic.Options.MemoryStoreOption(memoryStore),
+	)
+	if err != nil {
+		logger.Fatal("Failed to wire up service", zap.Error(err))
+	}
+	spanReader, err := storageBuild.NewSpanReader()
+	if err != nil {
+		logger.Fatal("Failed to get span reader", zap.Error(err))
+	}
+	dependencyReader, err := storageBuild.NewDependencyReader()
+	if err != nil {
+		logger.Fatal("Failed to get dependency reader", zap.Error(err))
+	}
+	rHandler := queryApp.NewAPIHandler(
+		spanReader,
+		dependencyReader,
+		queryApp.HandlerOptions.Prefix(*query.QueryPrefix),
+		queryApp.HandlerOptions.Logger(logger))
+	sHandler := queryApp.NewStaticAssetsHandler(*query.QueryStaticAssets)
+	r := mux.NewRouter()
+	rHandler.RegisterRoutes(r)
+	sHandler.RegisterRoutes(r)
+	portStr := ":" + strconv.Itoa(*query.QueryPort)
+	recoveryHandler := recoveryhandler.NewRecoveryHandler(logger, true)
+	logger.Info("Starting jaeger-query HTTP server", zap.Int("port", *query.QueryPort))
+	if err := http.ListenAndServe(portStr, recoveryHandler(r)); err != nil {
+		logger.Fatal("Could not launch service", zap.Error(err))
+	}
+}

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -22,35 +22,26 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"net"
-	"net/http"
-	"runtime"
-	"strconv"
-
-	"github.com/gorilla/mux"
-	"github.com/uber/tchannel-go"
-	"github.com/uber/tchannel-go/thrift"
 	"go.uber.org/zap"
+	"runtime"
 
-	"github.com/uber/jaeger-lib/metrics"
 	"github.com/uber/jaeger-lib/metrics/go-kit"
 	"github.com/uber/jaeger-lib/metrics/go-kit/expvar"
 	agentApp "github.com/uber/jaeger/cmd/agent/app"
-	basic "github.com/uber/jaeger/cmd/builder"
-	collector "github.com/uber/jaeger/cmd/collector/app/builder"
-	queryApp "github.com/uber/jaeger/cmd/query/app"
-	query "github.com/uber/jaeger/cmd/query/app/builder"
-	"github.com/uber/jaeger/pkg/recoveryhandler"
+	agentStarter "github.com/uber/jaeger/cmd/agent/starter"
+	collectorStarter "github.com/uber/jaeger/cmd/collector/starter"
+	queryStarter "github.com/uber/jaeger/cmd/query/starter"
 	"github.com/uber/jaeger/storage/spanstore/memory"
-	jc "github.com/uber/jaeger/thrift-gen/jaeger"
-	zc "github.com/uber/jaeger/thrift-gen/zipkincore"
+)
+
+const (
+	serviceName = "jaeger-standalone"
 )
 
 // standalone/main is a standalone full-stack jaeger backend, backed by a memory store
 func main() {
 	logger, _ := zap.NewProduction()
-	metricsFactory := xkit.Wrap("jaeger-standalone", expvar.NewFactory(10))
+	metricsFactory := xkit.Wrap(serviceName, expvar.NewFactory(10))
 	memStore := memory.NewStore()
 
 	builder := agentApp.NewBuilder()
@@ -59,94 +50,9 @@ func main() {
 
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
-	startAgent(logger, metricsFactory, builder)
-	startCollector(logger, metricsFactory, memStore)
-	startQuery(logger, metricsFactory, memStore)
+	agentStarter.StartAgent(logger, metricsFactory, builder)
+	collectorStarter.StartCollector(logger, metricsFactory, memStore)
+	queryStarter.StartQuery(logger, metricsFactory, memStore)
 
 	select {}
-}
-
-func startAgent(logger *zap.Logger, baseFactory metrics.Factory, builder *agentApp.Builder) {
-	metricsFactory := baseFactory.Namespace("jaeger-agent", nil)
-
-	if builder.CollectorHostPort == "" {
-		builder.CollectorHostPort = fmt.Sprintf("127.0.0.1:%d", *collector.CollectorPort)
-	}
-	agent, err := builder.CreateAgent(metricsFactory, logger)
-	if err != nil {
-		logger.Fatal("Unable to initialize Jaeger Agent", zap.Error(err))
-	}
-
-	logger.Info("Starting agent")
-	if err := agent.Run(); err != nil {
-		logger.Fatal("Failed to run the agent", zap.Error(err))
-	}
-}
-
-func startCollector(logger *zap.Logger, baseFactory metrics.Factory, memoryStore *memory.Store) {
-	metricsFactory := baseFactory.Namespace("jaeger-collector", nil)
-
-	spanBuilder, err := collector.NewSpanHandlerBuilder(
-		basic.Options.LoggerOption(logger),
-		basic.Options.MetricsFactoryOption(metricsFactory),
-		basic.Options.MemoryStoreOption(memoryStore),
-	)
-	if err != nil {
-		logger.Fatal("Unabled to set up builder", zap.Error(err))
-	}
-	zipkinSpansHandler, jaegerBatchesHandler, err := spanBuilder.BuildHandlers()
-	if err != nil {
-		logger.Fatal("Unable to build span handlers", zap.Error(err))
-	}
-
-	ch, err := tchannel.NewChannel("jaeger-collector", &tchannel.ChannelOptions{})
-	if err != nil {
-		logger.Fatal("Unable to create new New TChannel Channel", zap.Error(err))
-	}
-	server := thrift.NewServer(ch)
-	server.Register(jc.NewTChanCollectorServer(jaegerBatchesHandler))
-	server.Register(zc.NewTChanZipkinCollectorServer(zipkinSpansHandler))
-	portStr := ":" + strconv.Itoa(*collector.CollectorPort)
-	listener, err := net.Listen("tcp", portStr)
-	if err != nil {
-		logger.Fatal("Unabled to listen start listening on channel", zap.Error(err))
-	}
-	ch.Serve(listener)
-	logger.Info("Starting jaeger-collector TChannel server", zap.Int("port", *collector.CollectorPort))
-}
-
-func startQuery(logger *zap.Logger, baseFactory metrics.Factory, memoryStore *memory.Store) {
-	metricsFactory := baseFactory.Namespace("jaeger-query", nil)
-
-	storageBuild, err := query.NewStorageBuilder(
-		basic.Options.LoggerOption(logger),
-		basic.Options.MetricsFactoryOption(metricsFactory),
-		basic.Options.MemoryStoreOption(memoryStore),
-	)
-	if err != nil {
-		logger.Fatal("Failed to wire up service", zap.Error(err))
-	}
-	spanReader, err := storageBuild.NewSpanReader()
-	if err != nil {
-		logger.Fatal("Failed to get span reader", zap.Error(err))
-	}
-	dependencyReader, err := storageBuild.NewDependencyReader()
-	if err != nil {
-		logger.Fatal("Failed to get dependency reader", zap.Error(err))
-	}
-	rHandler := queryApp.NewAPIHandler(
-		spanReader,
-		dependencyReader,
-		queryApp.HandlerOptions.Prefix(*query.QueryPrefix),
-		queryApp.HandlerOptions.Logger(logger))
-	sHandler := queryApp.NewStaticAssetsHandler(*query.QueryStaticAssets)
-	r := mux.NewRouter()
-	rHandler.RegisterRoutes(r)
-	sHandler.RegisterRoutes(r)
-	portStr := ":" + strconv.Itoa(*query.QueryPort)
-	recoveryHandler := recoveryhandler.NewRecoveryHandler(logger, true)
-	logger.Info("Starting jaeger-query HTTP server", zap.Int("port", *query.QueryPort))
-	if err := http.ListenAndServe(portStr, recoveryHandler(r)); err != nil {
-		logger.Fatal("Could not launch service", zap.Error(err))
-	}
 }


### PR DESCRIPTION
With this commit, the individual modules are now started using the
same procedure as the standalone. This fixes the problem with the
collector, where it would require Cassandra options even when an
in-memory option had been set.