### PR TITLE
Reduce size of all in one image

### DIFF
--- a/cmd/standalone/Dockerfile
+++ b/cmd/standalone/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.7
+FROM scratch
 # expose agent UDP ports and query port
 EXPOSE 5775/udp 6831/udp 6832/udp 16686
 
 COPY ./jaeger-ui-build /go/src/jaeger-ui-build
 COPY ./cmd/standalone/standalone-linux /go/bin/
 
-ENTRYPOINT /go/bin/standalone-linux --span-storage.type=memory --query.static-files=/go/src/jaeger-ui-build/build/
+CMD ["/go/bin/standalone-linux","--span-storage.type=memory","--query.static-files=/go/src/jaeger-ui-build/build/"]

--- a/cmd/standalone/Dockerfile
+++ b/cmd/standalone/Dockerfile
@@ -1,6 +1,6 @@
 FROM scratch
-# expose agent UDP ports and query port
-EXPOSE 5775/udp 6831/udp 6832/udp 16686
+# expose agent UDP and sampling ports and query port
+EXPOSE 5775/udp 6831/udp 6832/udp 5778 16686
 
 COPY ./jaeger-ui-build /go/src/jaeger-ui-build
 COPY ./cmd/standalone/standalone-linux /go/bin/


### PR DESCRIPTION
707MB -> 31MB using an empty docker image. Had to swap from ENTRYPOINT to CMD because ENTRYPOINT requires bash and the scratch container doesn't even have that.