### PR TITLE
Add default for cassandra.connections-per-host

### DIFF
--- a/cmd/flags/cassandra/options.go
+++ b/cmd/flags/cassandra/options.go
@@ -51,9 +51,10 @@ func NewOptions() *Options {
 	return &Options{
 		primary: &namespaceConfig{
 			Configuration: config.Configuration{
-				MaxRetryAttempts: 3,
-				Keyspace:         "jaeger_v1_local",
-				ProtoVersion:     4,
+				MaxRetryAttempts:   3,
+				Keyspace:           "jaeger_v1_local",
+				ProtoVersion:       4,
+				ConnectionsPerHost: 2,
 			},
 			servers: "127.0.0.1",
 		},

--- a/cmd/flags/cassandra/options_test.go
+++ b/cmd/flags/cassandra/options_test.go
@@ -33,10 +33,12 @@ func TestOptions(t *testing.T) {
 	primary := opts.GetPrimary()
 	assert.NotEmpty(t, primary.Keyspace)
 	assert.NotEmpty(t, primary.Servers)
+	assert.Equal(t, 2, primary.ConnectionsPerHost)
 
 	aux := opts.Get("archive")
 	assert.Equal(t, primary.Keyspace, aux.Keyspace)
 	assert.Equal(t, primary.Servers, aux.Servers)
+	assert.Equal(t, primary.ConnectionsPerHost, aux.ConnectionsPerHost)
 }
 
 func TestOptionsWithFlags(t *testing.T) {

--- a/crossdock/main.go
+++ b/crossdock/main.go
@@ -122,7 +122,7 @@ func (h *clientHandler) isInitialized() bool {
 // InitializeCollector initializes the jaeger collector
 func InitializeCollector(logger *zap.Logger) {
 	cmd := exec.Command("/bin/sh", "-c",
-		fmt.Sprintf(collectorCmd, "-cassandra.keyspace=jaeger -cassandra.servers=cassandra -cassandra.connections-per-host=1"))
+		fmt.Sprintf(collectorCmd, "-cassandra.keyspace=jaeger -cassandra.servers=cassandra"))
 	if err := cmd.Run(); err != nil {
 		logger.Fatal("Failed to initialize collector service", zap.Error(err))
 	}
@@ -132,7 +132,7 @@ func InitializeCollector(logger *zap.Logger) {
 // NewQueryService initiates the query service
 func NewQueryService(url string, logger *zap.Logger) services.QueryService {
 	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf(queryCmd,
-		"-cassandra.keyspace=jaeger -cassandra.servers=cassandra -cassandra.connections-per-host=1"))
+		"-cassandra.keyspace=jaeger -cassandra.servers=cassandra"))
 	if err := cmd.Run(); err != nil {
 		logger.Fatal("Failed to initialize query service", zap.Error(err))
 	}


### PR DESCRIPTION
If the user doesn't pass in the flag cassandra.connections-per-host when initializing collector or query services, the initialization will fail. Adding a default to prevent this.

The actual default is up for debate.