### PR TITLE
Skip upload to docker hub from forked repo PRs

### DIFF
--- a/travis/build-all-in-one-image.sh
+++ b/travis/build-all-in-one-image.sh
@@ -15,6 +15,6 @@ make integration-test
 docker kill $CID
 
 # Only push the docker container to Docker Hub for master branch
-if [ "$BRANCH" == "master" && "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then echo 'upload to Docker Hub'; else echo 'skip docker upload for PR'; exit 0; fi
+if [[ "$BRANCH" == "master" && "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then echo 'upload to Docker Hub'; else echo 'skip docker upload for PR'; exit 0; fi
 
 bash ./travis/upload-to-docker.sh

--- a/travis/build-all-in-one-image.sh
+++ b/travis/build-all-in-one-image.sh
@@ -15,6 +15,6 @@ make integration-test
 docker kill $CID
 
 # Only push the docker container to Docker Hub for master branch
-if [ "$BRANCH" == "master" ]; then echo 'upload to Docker Hub'; else echo 'skip docker upload for PR'; exit 0; fi
+if [ "$BRANCH" == "master" && "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then echo 'upload to Docker Hub'; else echo 'skip docker upload for PR'; exit 0; fi
 
 bash ./travis/upload-to-docker.sh

--- a/travis/build-crossdock.sh
+++ b/travis/build-crossdock.sh
@@ -8,7 +8,7 @@ export REPO=jaegertracing/test-driver
 export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 
 # Only push the docker container to Docker Hub for master branch
-if [ "$BRANCH" == "master" && "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then echo 'upload to Docker Hub'; else echo 'skip docker upload for PR'; exit 0; fi
+if [[ "$BRANCH" == "master" && "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then echo 'upload to Docker Hub'; else echo 'skip docker upload for PR'; exit 0; fi
 
 docker build -f crossdock/Dockerfile -t $REPO:$COMMIT .
 

--- a/travis/build-crossdock.sh
+++ b/travis/build-crossdock.sh
@@ -8,7 +8,7 @@ export REPO=jaegertracing/test-driver
 export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 
 # Only push the docker container to Docker Hub for master branch
-if [ "$BRANCH" == "master" ]; then echo 'upload to Docker Hub'; else echo 'skip docker upload for PR'; exit 0; fi
+if [ "$BRANCH" == "master" && "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then echo 'upload to Docker Hub'; else echo 'skip docker upload for PR'; exit 0; fi
 
 docker build -f crossdock/Dockerfile -t $REPO:$COMMIT .
 


### PR DESCRIPTION
When a good samaritan creates a PR from a forked version of jaeger, we run into a problem when running the following:

`if [ "$BRANCH" == "master" ]; then echo 'upload to Docker Hub'; else echo 'skip docker upload for PR'; exit 0; fi`

because the branch is "master". Travis will attempt to upload the docker image to docker hub but the encrypted environment variables (docker hub username and password) are not available for forked repos. This results in the travis build being stuck for 10 minutes before timing out.

Given that travis doesn't provide a way to check if the current build is from a fork, I'm using `"$TRAVIS_SECURE_ENV_VARS" == "true"` to determine if the encrypted environment variables are available which signals that the build is a non-forked version.