### PR TITLE
Remove TChannel thrift client options

### DIFF
--- a/cmd/agent/app/processors/thrift_processor_test.go
+++ b/cmd/agent/app/processors/thrift_processor_test.go
@@ -83,7 +83,7 @@ func createProcessor(t *testing.T, mFactory metrics.Factory, tFactory thrift.TPr
 
 func initCollectorAndReporter(t *testing.T) (*metrics.LocalFactory, *testutils.MockTCollector, reporter.Reporter) {
 	metricsFactory, collector := testutils.InitMockCollector(t)
-	reporter := reporter.NewTChannelReporter("jaeger-collector", collector.Channel, metricsFactory, zap.NewNop(), nil)
+	reporter := reporter.NewTChannelReporter("jaeger-collector", collector.Channel, metricsFactory, zap.NewNop())
 	return metricsFactory, collector, reporter
 }
 

--- a/cmd/agent/app/reporter/tchannel_reporter.go
+++ b/cmd/agent/app/reporter/tchannel_reporter.go
@@ -63,8 +63,8 @@ type tchannelReporter struct {
 }
 
 // NewTChannelReporter creates new tchannelReporter
-func NewTChannelReporter(svc string, channel *tchannel.Channel, mFactory metrics.Factory, zlogger *zap.Logger, clientOpts *thrift.ClientOptions) Reporter {
-	thriftClient := thrift.NewClient(channel, svc, clientOpts)
+func NewTChannelReporter(svc string, channel *tchannel.Channel, mFactory metrics.Factory, zlogger *zap.Logger) Reporter {
+	thriftClient := thrift.NewClient(channel, svc, nil)
 	zClient := zipkincore.NewTChanZipkinCollectorClient(thriftClient)
 	jClient := jaeger.NewTChanCollectorClient(thriftClient)
 	batchesMetrics := map[string]batchMetrics{}

--- a/cmd/agent/app/reporter/tchannel_reporter_test.go
+++ b/cmd/agent/app/reporter/tchannel_reporter_test.go
@@ -38,7 +38,7 @@ import (
 
 func initRequirements(t *testing.T) (*metrics.LocalFactory, *testutils.MockTCollector, Reporter) {
 	metricsFactory, collector := testutils.InitMockCollector(t)
-	reporter := NewTChannelReporter("jaeger-collector", collector.Channel, metricsFactory, zap.NewNop(), nil)
+	reporter := NewTChannelReporter("jaeger-collector", collector.Channel, metricsFactory, zap.NewNop())
 	return metricsFactory, collector, reporter
 }
 

--- a/cmd/agent/app/sampling/collector_proxy.go
+++ b/cmd/agent/app/sampling/collector_proxy.go
@@ -42,8 +42,8 @@ type collectorProxy struct {
 }
 
 // NewCollectorProxy implements Manager by proxying the requests to collector.
-func NewCollectorProxy(svc string, channel *tchannel.Channel, mFactory metrics.Factory, clientOpts *thrift.ClientOptions) Manager {
-	thriftClient := thrift.NewClient(channel, svc, clientOpts)
+func NewCollectorProxy(svc string, channel *tchannel.Channel, mFactory metrics.Factory) Manager {
+	thriftClient := thrift.NewClient(channel, svc, nil)
 	client := sampling.NewTChanSamplingManagerClient(thriftClient)
 	res := &collectorProxy{client: client}
 	metrics.Init(&res.metrics, mFactory, nil)

--- a/cmd/agent/app/sampling/collector_proxy_test.go
+++ b/cmd/agent/app/sampling/collector_proxy_test.go
@@ -45,7 +45,7 @@ func TestCollectorProxy(t *testing.T) {
 			MaxTracesPerSecond: 10,
 		}})
 
-	mgr := NewCollectorProxy("jaeger-collector", collector.Channel, metricsFactory, nil)
+	mgr := NewCollectorProxy("jaeger-collector", collector.Channel, metricsFactory)
 
 	resp, err := mgr.GetSamplingStrategy("service1")
 	require.NoError(t, err)


### PR DESCRIPTION
Fixed discoverer with static hosts have made the client options obsolete.