### PR TITLE
Docs add link to oc, k8s templates and links to all repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ See also:
 
 Most of the code here is used in production at Uber, but the open source version is currently in **Public Beta**.
 
+## Related Repositories
+Clients:
+ * [Go client](https://github.com/uber/jaeger-client-go)
+ * [Java client](https://github.com/uber/jaeger-client-java)
+ * [Python client](https://github.com/uber/jaeger-client-python)
+ * [Node.js client](https://github.com/uber/jaeger-client-node)
+
+Contributions:
+ * [Jaeger contributions](https://github.com/jaegertracing) organization
+
+Components:
+ * [UI](https://github.com/uber/jaeger-ui)
+ * [Data model](https://github.com/uber/jaeger-idl)
+
 ## Contributing
 
 See [CONTRIBUTING](./CONTRIBUTING.md).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,6 +12,10 @@ docker run -d -p5775:5775/udp -p16686:16686 jaegertracing/all-in-one:latest
 
 You can then navigate to `http://localhost:16686` to access the Jaeger UI. 
 
+## Kubernetes and OpenShift
+Kubernetes and OpenShift templates can be found in [Jaegertracing](https://github.com/jaegertracing/) organization on
+Github.
+
 ## Sample Application
 
 ### HotROD (Rides on Demand)


### PR DESCRIPTION
* Add links to all jaeger related repositories to root readme
* add section about kubernetes and OC to docs