### PR TITLE
Remove zipkin span sanitizer logs

### DIFF
--- a/cmd/collector/app/sanitizer/zipkin/span_sanitizer.go
+++ b/cmd/collector/app/sanitizer/zipkin/span_sanitizer.go
@@ -82,14 +82,12 @@ type spanDurationSanitizer struct {
 func (s *spanDurationSanitizer) Sanitize(span *zc.Span) *zc.Span {
 	if span.Duration == nil {
 		span.Duration = &defaultDuration
-		s.log.ForSpan(span).Warn("Span did not have duration")
 		return span
 	}
 	duration := *span.Duration
 	if duration >= 0 {
 		return span
 	}
-	s.log.ForSpan(span).Error("Span had negative duration")
 	span.Duration = &defaultDuration
 	annotation := zc.BinaryAnnotation{
 		Key:            negativeDurationTag,

--- a/cmd/collector/app/sanitizer/zipkin/span_sanitizer_test.go
+++ b/cmd/collector/app/sanitizer/zipkin/span_sanitizer_test.go
@@ -46,7 +46,7 @@ func TestChainedSanitizer(t *testing.T) {
 }
 
 func TestSpanDurationSanitizer(t *testing.T) {
-	logger, log := testutils.NewLogger()
+	logger, _ := testutils.NewLogger()
 
 	sanitizer := NewSpanDurationSanitizer(logger)
 
@@ -55,22 +55,19 @@ func TestSpanDurationSanitizer(t *testing.T) {
 	assert.Equal(t, positiveDuration, *actual.Duration)
 	assert.Len(t, actual.BinaryAnnotations, 1)
 	assert.Equal(t, "-1", string(actual.BinaryAnnotations[0].Value))
-	assert.NotEmpty(t, log.Bytes())
 
-	logger, log = testutils.NewLogger()
+	logger, _ = testutils.NewLogger()
 	sanitizer = NewSpanDurationSanitizer(logger)
 	span = &zipkincore.Span{Duration: &positiveDuration}
 	actual = sanitizer.Sanitize(span)
 	assert.Equal(t, positiveDuration, *actual.Duration)
 	assert.Len(t, actual.BinaryAnnotations, 0)
-	assert.Empty(t, log.Bytes())
 
-	logger, log = testutils.NewLogger()
+	logger, _ = testutils.NewLogger()
 	sanitizer = NewSpanDurationSanitizer(logger)
 	nilDurationSpan := &zipkincore.Span{}
 	actual = sanitizer.Sanitize(nilDurationSpan)
 	assert.Equal(t, int64(1), *actual.Duration)
-	assert.NotEmpty(t, log.Bytes())
 }
 
 func TestSpanParentIDSanitizer(t *testing.T) {


### PR DESCRIPTION
This data is already stored in the span, and can be queried via tag search or duration search.