### PR TITLE
Fix race condition in testutils.logger

### DIFF
--- a/pkg/testutils/logger_test.go
+++ b/pkg/testutils/logger_test.go
@@ -65,6 +65,7 @@ var keepReading = func(buffer *Buffer, quit chan struct{}) {
 			return
 		default:
 			buffer.Lines()
+			buffer.Stripped()
 		}
 	}
 }


### PR DESCRIPTION
You can't both write and read from testutils.logger buffer concurrently given buffer is not threadsafe. Overwriting some functions with locks to fix.