### PR TITLE
Add the packaging metadata to build the jaeger snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: jaeger
+version: master
+summary: Distributed Tracing System
+description: |
+  Jaeger can be used for monitoring microservice-based architectures:
+
+  Distributed context propagation
+  Distributed transaction monitoring
+  Root cause analysis
+  Service dependency analysis
+  Performance / latency optimization
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  agent:
+    command: agent
+    plugs: [network, network-bind]
+
+parts:
+  jaeger:
+    source: .
+    plugin: go
+    go-importpath: github.com/uber/jaeger
+    after: [go]
+  go:
+    source-tag: go1.7.5


### PR DESCRIPTION
This package will let you publish the latest jaeger in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress.