### PR TITLE
Fix ES Storage integration test

### DIFF
--- a/plugin/storage/integration/es_integration_test.go
+++ b/plugin/storage/integration/es_integration_test.go
@@ -75,6 +75,9 @@ func (s *ESStorageIntegration) initializeES() error {
 
 func (s *ESStorageIntegration) esCleanUp() error {
 	_, err := s.client.DeleteIndex("*").Do(context.Background())
+	client := es.WrapESClient(s.client)
+	s.writer = spanstore.NewSpanWriter(client, s.logger)
+	s.reader = spanstore.NewSpanReader(client, s.logger, 72*time.Hour)
 	return err
 }
 

--- a/plugin/storage/integration/es_integration_test.go
+++ b/plugin/storage/integration/es_integration_test.go
@@ -58,15 +58,11 @@ func (s *ESStorageIntegration) initializeES() error {
 	if err != nil {
 		return err
 	}
-	client := es.WrapESClient(rawClient)
 	logger, _ := testutils.NewLogger()
-	writer := spanstore.NewSpanWriter(client, logger)
-	reader := spanstore.NewSpanReader(client, logger, 72*time.Hour)
 
 	s.client = rawClient
-	s.writer = writer
-	s.reader = reader
 	s.logger = logger
+	s.initSpanstore()
 	s.cleanUp = s.esCleanUp
 	s.refresh = s.esRefresh
 	s.cleanUp()
@@ -75,10 +71,14 @@ func (s *ESStorageIntegration) initializeES() error {
 
 func (s *ESStorageIntegration) esCleanUp() error {
 	_, err := s.client.DeleteIndex("*").Do(context.Background())
+	s.initSpanstore()
+	return err
+}
+
+func (s *ESStorageIntegration) initSpanstore() {
 	client := es.WrapESClient(s.client)
 	s.writer = spanstore.NewSpanWriter(client, s.logger)
 	s.reader = spanstore.NewSpanReader(client, s.logger, 72*time.Hour)
-	return err
 }
 
 func (s *ESStorageIntegration) esRefresh() error {

--- a/travis/es-integration-test.sh
+++ b/travis/es-integration-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 docker pull docker.elastic.co/elasticsearch/elasticsearch:5.4.0
 export CID=$(docker run -d -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" docker.elastic.co/elasticsearch/elasticsearch:5.4.0)
 export ES_INTEGRATION_TEST=test


### PR DESCRIPTION
the writer cache attached in previous commit was interfering with the integration tests because each test wasn't initialized/cleaned up properly