### PR TITLE
Support configurable metrics backend in the agent

### DIFF
--- a/cmd/agent/app/agent_test.go
+++ b/cmd/agent/app/agent_test.go
@@ -29,13 +29,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 )
 
 func TestAgentStartError(t *testing.T) {
 	cfg := &Builder{}
-	agent, err := cfg.CreateAgent(metrics.NullFactory, zap.NewNop())
+	agent, err := cfg.CreateAgent(zap.NewNop())
 	require.NoError(t, err)
 	agent.httpServer.Addr = "bad-address"
 	assert.Error(t, agent.Run())
@@ -53,7 +52,7 @@ func TestAgentStartStop(t *testing.T) {
 			},
 		},
 	}
-	agent, err := cfg.CreateAgent(metrics.NullFactory, zap.NewNop())
+	agent, err := cfg.CreateAgent(zap.NewNop())
 	require.NoError(t, err)
 	ch := make(chan error, 2)
 	go func() {

--- a/cmd/agent/app/builder.go
+++ b/cmd/agent/app/builder.go
@@ -36,6 +36,7 @@ import (
 	tchreporter "github.com/uber/jaeger/cmd/agent/app/reporter/tchannel"
 	"github.com/uber/jaeger/cmd/agent/app/servers"
 	"github.com/uber/jaeger/cmd/agent/app/servers/thriftudp"
+	jmetrics "github.com/uber/jaeger/pkg/metrics"
 	zipkinThrift "github.com/uber/jaeger/thrift-gen/agent"
 	jaegerThrift "github.com/uber/jaeger/thrift-gen/jaeger"
 )
@@ -74,8 +75,9 @@ var (
 type Builder struct {
 	Processors []ProcessorConfiguration `yaml:"processors"`
 	HTTPServer HTTPServerConfiguration  `yaml:"httpServer"`
+	Metrics    jmetrics.Builder         `yaml:"metrics"`
 
-	// These 3 fields are copied from reporter.Builder because yaml does not parse embedded structs
+	// These 3 fields are copied from tchreporter.Builder because yaml does not parse embedded structs
 	CollectorHostPorts   []string `yaml:"collectorHostPorts"`
 	DiscoveryMinPeers    int      `yaml:"minPeers"`
 	CollectorServiceName string   `yaml:"collectorServiceName"`
@@ -83,6 +85,7 @@ type Builder struct {
 	tchreporter.Builder
 
 	otherReporters []reporter.Reporter
+	metricsFactory metrics.Factory
 }
 
 // NewBuilder creates a default builder with three processors.
@@ -152,6 +155,12 @@ func (b *Builder) WithReporter(r reporter.Reporter) *Builder {
 	return b
 }
 
+// WithMetricsFactory sets an externally initialized metrics factory.
+func (b *Builder) WithMetricsFactory(mf metrics.Factory) *Builder {
+	b.metricsFactory = mf
+	return b
+}
+
 func (b *Builder) createMainReporter(mFactory metrics.Factory, logger *zap.Logger) (*tchreporter.Reporter, error) {
 	if len(b.Builder.CollectorHostPorts) == 0 {
 		b.Builder.CollectorHostPorts = b.CollectorHostPorts
@@ -165,8 +174,19 @@ func (b *Builder) createMainReporter(mFactory metrics.Factory, logger *zap.Logge
 	return b.Builder.CreateReporter(mFactory, logger)
 }
 
+func (b *Builder) getMetricsFactory() (metrics.Factory, error) {
+	if b.metricsFactory != nil {
+		return b.metricsFactory, nil
+	}
+	return b.Metrics.CreateMetricsFactory("jaeger_agent")
+}
+
 // CreateAgent creates the Agent
-func (b *Builder) CreateAgent(mFactory metrics.Factory, logger *zap.Logger) (*Agent, error) {
+func (b *Builder) CreateAgent(logger *zap.Logger) (*Agent, error) {
+	mFactory, err := b.getMetricsFactory()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create metrics factory")
+	}
 	mainReporter, err := b.createMainReporter(mFactory, logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create main Reporter")
@@ -181,6 +201,9 @@ func (b *Builder) CreateAgent(mFactory metrics.Factory, logger *zap.Logger) (*Ag
 		return nil, err
 	}
 	httpServer := b.HTTPServer.GetHTTPServer(b.CollectorServiceName, mainReporter.Channel(), mFactory)
+	if b.metricsFactory == nil {
+		b.Metrics.RegisterHandler(httpServer.Handler.(*http.ServeMux))
+	}
 	return NewAgent(processors, httpServer, logger), nil
 }
 

--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -27,10 +27,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 
-	"github.com/uber/jaeger-lib/metrics"
 	"github.com/uber/jaeger/thrift-gen/jaeger"
 	"github.com/uber/jaeger/thrift-gen/zipkincore"
 )

--- a/cmd/agent/app/builder_test.go
+++ b/cmd/agent/app/builder_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/jaeger-lib/metrics"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 
@@ -119,7 +118,7 @@ func TestBuilderFromConfig(t *testing.T) {
 func TestBuilderWithExtraReporter(t *testing.T) {
 	cfg := &Builder{}
 	cfg.WithReporter(fakeReporter{})
-	agent, err := cfg.CreateAgent(metrics.NullFactory, zap.NewNop())
+	agent, err := cfg.CreateAgent(zap.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, agent)
 }
@@ -127,7 +126,7 @@ func TestBuilderWithExtraReporter(t *testing.T) {
 func TestBuilderWithError(t *testing.T) {
 	cfg := &Builder{}
 	cfg.WithDiscoverer(fakeDiscoverer{})
-	agent, err := cfg.CreateAgent(metrics.NullFactory, zap.NewNop())
+	agent, err := cfg.CreateAgent(zap.NewNop())
 	assert.Error(t, err)
 	assert.Nil(t, agent)
 }
@@ -158,7 +157,7 @@ func TestBuilderWithProcessorErrors(t *testing.T) {
 				},
 			},
 		}
-		_, err := cfg.CreateAgent(metrics.NullFactory, zap.NewNop())
+		_, err := cfg.CreateAgent(zap.NewNop())
 		assert.Error(t, err)
 		if testCase.err != "" {
 			assert.EqualError(t, err, testCase.err)

--- a/cmd/agent/app/flags.go
+++ b/cmd/agent/app/flags.go
@@ -28,6 +28,7 @@ import (
 
 // Bind binds the agent builder to command line options
 func (b *Builder) Bind(flags *flag.FlagSet) {
+	b.Metrics.Bind(flags)
 	for i := range b.Processors {
 		p := &b.Processors[i]
 		name := "processor." + string(p.Model) + "-" + string(p.Protocol) + "."

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -26,8 +26,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"fmt"
-
 	"github.com/uber/jaeger/cmd/agent/app"
 )
 
@@ -35,8 +33,6 @@ func main() {
 	builder := app.NewBuilder()
 	builder.Bind(flag.CommandLine)
 	flag.Parse()
-
-	fmt.Printf("%+v\n", builder)
 
 	runtime.GOMAXPROCS(runtime.NumCPU())
 

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -74,7 +74,7 @@ func startAgent(logger *zap.Logger, baseFactory metrics.Factory, builder *agentA
 	if len(builder.CollectorHostPorts) == 0 {
 		builder.CollectorHostPorts = append(builder.CollectorHostPorts, fmt.Sprintf("127.0.0.1:%d", *collector.CollectorPort))
 	}
-	agent, err := builder.CreateAgent(metricsFactory, logger)
+	agent, err := builder.WithMetricsFactory(metricsFactory).CreateAgent(logger)
 	if err != nil {
 		logger.Fatal("Unable to initialize Jaeger Agent", zap.Error(err))
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,14 @@
-hash: 84da4d5dfad787c610afb31cf486aa1f586dfeffc121ad8b4346fd5f0b82f6d1
-updated: 2017-06-23T17:48:26.722215035-04:00
+hash: 0422930e1449cb67e320706a40592e7b386e86fb80cead37945e2c12133a9ae2
+updated: 2017-07-16T14:46:02.785298314-04:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
   subpackages:
   - lib/go/thrift
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
 - name: github.com/codahale/hdrhistogram
   version: f8ad88b59a584afeee9d334eff879b104439117b
 - name: github.com/crossdock/crossdock-go
@@ -13,24 +17,29 @@ imports:
   - assert
   - require
 - name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  version: adab96458c51a58dc1783b3335dcce5461522e75
   subpackages:
   - spew
 - name: github.com/fsnotify/fsnotify
   version: 30411dbcefb7a1da7e84f75530ad3abe4011b4f8
 - name: github.com/go-kit/kit
-  version: fadad6fffe0466b19df9efd9acde5c9a52df5fa4
+  version: a9ca6725cbbea455e61c6bc8a1ed28e81eb3493b
   subpackages:
   - metrics
   - metrics/expvar
   - metrics/generic
   - metrics/internal/lv
+  - metrics/prometheus
 - name: github.com/gocql/gocql
   version: 4d2d1ac71932f7c4a6c7feb0d654462e4116c58b
   subpackages:
   - internal/lru
   - internal/murmur
   - internal/streams
+- name: github.com/golang/protobuf
+  version: 7cc19b78d562895b13596ddce7aafb59dd789318
+  subpackages:
+  - proto
 - name: github.com/golang/snappy
   version: d7b1e156f50d3c4664f683603af70e3e47fa0aa2
 - name: github.com/gorilla/context
@@ -58,6 +67,10 @@ imports:
   version: cfb55aafdaf3ec08f0db22699ab822c50091b1c4
 - name: github.com/magiconair/properties
   version: 9c47895dc1ce54302908ab8a43385d1f5df2c11c
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
 - name: github.com/mitchellh/mapstructure
   version: bfdb1a85537d60bc7e954e600c250219ea497417
 - name: github.com/olivere/elastic
@@ -81,6 +94,25 @@ imports:
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+  - prometheus/promhttp
+- name: github.com/prometheus/client_model
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  subpackages:
+  - xfs
 - name: github.com/spf13/afero
   version: 90dd71edc4d0a8b3511dc12ea15d617d03be09e0
   subpackages:
@@ -98,7 +130,7 @@ imports:
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
-  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  version: 05e8a0eda380579888eb53c394909df027f06991
   subpackages:
   - assert
   - mock
@@ -106,7 +138,7 @@ imports:
 - name: github.com/uber-go/atomic
   version: 0c9e689d64f004564b79d9a663634756df322902
 - name: github.com/uber/jaeger-client-go
-  version: 921405f1ad4348f04735f9cc7dd6cc46483daeda
+  version: d021e646f5187d77b55592c3efee1a2810e895d7
   subpackages:
   - config
   - internal/spanlog
@@ -120,11 +152,12 @@ imports:
   - transport/zipkin
   - utils
 - name: github.com/uber/jaeger-lib
-  version: ffca3143c929e9b97325e6bebcc380e8c6e5fa0d
+  version: 13219516eeab40f3b23e4d50e3f91a0d68064afc
   subpackages:
   - metrics
   - metrics/go-kit
   - metrics/go-kit/expvar
+  - metrics/go-kit/prometheus
   - metrics/testutils
 - name: github.com/uber/tchannel-go
   version: 1a0e35378f6f721bc07f6c4466bc9701ed70b506
@@ -154,7 +187,7 @@ imports:
   - zapcore
   - zaptest
 - name: golang.org/x/net
-  version: 5b58a9c3e1690d33a592e5b791638e25eb9b3f70
+  version: b3756b4b77d7b13260a0a2ec658753cf48922eac
   subpackages:
   - context
   - context/ctxhttp
@@ -174,7 +207,7 @@ imports:
   subpackages:
   - uritemplates
 - name: gopkg.in/yaml.v2
-  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
+  version: 3b4ad1db5b2a649883ff3782f5f9f6fb52be71af
 testImports:
 - name: github.com/kr/text
   version: 7cafcd837844e784b526369c9bce262804aebc60

--- a/glide.yaml
+++ b/glide.yaml
@@ -18,7 +18,7 @@ import:
   subpackages:
   - transport
 - package: github.com/uber/jaeger-lib
-  version: ffca3143c929e9b97325e6bebcc380e8c6e5fa0d
+  version: 13219516eeab40f3b23e4d50e3f91a0d68064afc
 - package: github.com/uber/tchannel-go
   version: v1.1.0
   subpackages:
@@ -36,7 +36,7 @@ import:
   subpackages:
   - nethttp
 - package: github.com/go-kit/kit
-  version: v0.4.0
+  version: v0.5.0
   subpackages:
   - metrics
 - package: github.com/olivere/elastic

--- a/pkg/metrics/builder.go
+++ b/pkg/metrics/builder.go
@@ -39,7 +39,7 @@ var errUnknownBackend = errors.New("unknown metrics backend specified")
 // Builder provides command line options to configure metrics backend used by Jaeger executables.
 type Builder struct {
 	Backend   string
-	HTTPRoute string
+	HTTPRoute string // endpoint name to expose metrics, e.g. for scraping
 
 	handler http.Handler
 }

--- a/pkg/metrics/builder.go
+++ b/pkg/metrics/builder.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"errors"
+	"flag"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	xkit "github.com/uber/jaeger-lib/metrics/go-kit"
+	kitexpvar "github.com/uber/jaeger-lib/metrics/go-kit/expvar"
+	kitprom "github.com/uber/jaeger-lib/metrics/go-kit/prometheus"
+	"github.com/uber/jaeger/examples/hotrod/pkg/httpexpvar"
+
+	"github.com/uber/jaeger-lib/metrics"
+)
+
+var errUnknownBackend = errors.New("unknown metrics backend specified")
+
+// Builder provides command line options to configure metrics backend used by Jaeger executables.
+type Builder struct {
+	Backend   string
+	HTTPRoute string
+
+	handler http.Handler
+}
+
+// Bind defines command line flags and binds their values to the builder fields.
+func (b *Builder) Bind(flagSet *flag.FlagSet) {
+	flagSet.StringVar(
+		&b.Backend,
+		"metrics-backend",
+		"expvar",
+		"Defines which metrics backend to use for metrics reporting: prometheus, expvar, none")
+	flagSet.StringVar(
+		&b.HTTPRoute,
+		"metrics-http-route",
+		"/debug/vars",
+		"Defines the route of HTTP endpoint for metrics backends that support scraping")
+}
+
+// CreateMetricsFactory creates a metrics factory based on the configured type of the backend.
+// If the metrics backend supports HTTP endpoint for scraping, it is stored in the builder and
+// can be later added by RegisterHandler function.
+func (b *Builder) CreateMetricsFactory(namespace string) (metrics.Factory, error) {
+	if b.Backend == "prometheus" {
+		metricsFactory := xkit.Wrap(namespace, kitprom.NewFactory("", "", nil))
+		b.handler = promhttp.Handler()
+		return metricsFactory, nil
+	}
+	if b.Backend == "expvar" {
+		metricsFactory := xkit.Wrap(namespace, kitexpvar.NewFactory(10))
+		// TODO register official expvar handler once we upgrade to Go 1.8
+		b.handler = http.HandlerFunc(httpexpvar.Handler)
+		return metricsFactory, nil
+	}
+	if b.Backend == "none" {
+		return metrics.NullFactory, nil
+	}
+	return nil, errUnknownBackend
+}
+
+// RegisterHandler adds an endpoint to the mux if the metrics backend supports it.
+func (b *Builder) RegisterHandler(mux *http.ServeMux) {
+	if b.handler != nil && b.HTTPRoute != "" {
+		mux.Handle(b.HTTPRoute, b.handler)
+	}
+}

--- a/pkg/metrics/builder.go
+++ b/pkg/metrics/builder.go
@@ -73,7 +73,7 @@ func (b *Builder) CreateMetricsFactory(namespace string) (metrics.Factory, error
 		b.handler = http.HandlerFunc(httpexpvar.Handler)
 		return metricsFactory, nil
 	}
-	if b.Backend == "none" {
+	if b.Backend == "none" || b.Backend == "" {
 		return metrics.NullFactory, nil
 	}
 	return nil, errUnknownBackend

--- a/pkg/metrics/builder_test.go
+++ b/pkg/metrics/builder_test.go
@@ -1,3 +1,68 @@
 package metrics
 
-// TODO
+import (
+	"net/http"
+	"testing"
+
+	"flag"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBind(t *testing.T) {
+	b := &Builder{}
+	flags := flag.NewFlagSet("foo", flag.PanicOnError)
+	b.Bind(flags)
+}
+
+func TestBuilder(t *testing.T) {
+	testCases := []struct {
+		backend string
+		route   string
+		err     error
+		handler bool
+	}{
+		{
+			backend: "expvar",
+			route:   "/",
+			handler: true,
+		},
+		{
+			backend: "prometheus",
+			route:   "/",
+			handler: true,
+		},
+		{
+			backend: "none",
+			handler: false,
+		},
+		{
+			backend: "",
+			handler: false,
+		},
+		{
+			backend: "invalid",
+			err:     errUnknownBackend,
+		},
+	}
+
+	for i := range testCases {
+		testCase := testCases[i]
+		b := &Builder{
+			Backend:   testCase.backend,
+			HTTPRoute: testCase.route,
+		}
+		mf, err := b.CreateMetricsFactory("foo")
+		if testCase.err != nil {
+			assert.Equal(t, err, testCase.err)
+			continue
+		}
+		require.NotNil(t, mf)
+		if testCase.handler {
+			require.NotNil(t, b.handler)
+			mux := http.NewServeMux()
+			b.RegisterHandler(mux)
+		}
+	}
+}

--- a/pkg/metrics/builder_test.go
+++ b/pkg/metrics/builder_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package metrics
 
 import (

--- a/pkg/metrics/builder_test.go
+++ b/pkg/metrics/builder_test.go
@@ -1,0 +1,3 @@
+package metrics
+
+// TODO

--- a/pkg/metrics/builder_test.go
+++ b/pkg/metrics/builder_test.go
@@ -21,10 +21,9 @@
 package metrics
 
 import (
+	"flag"
 	"net/http"
 	"testing"
-
-	"flag"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/metrics/package.go
+++ b/pkg/metrics/package.go
@@ -18,41 +18,5 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
-
-import (
-	"flag"
-	"runtime"
-
-	"go.uber.org/zap"
-
-	"fmt"
-
-	"github.com/uber/jaeger/cmd/agent/app"
-)
-
-func main() {
-	builder := app.NewBuilder()
-	builder.Bind(flag.CommandLine)
-	flag.Parse()
-
-	fmt.Printf("%+v\n", builder)
-
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
-	logger, _ := zap.NewProduction()
-
-	// TODO illustrate discovery service wiring
-	// TODO illustrate additional reporter
-
-	agent, err := builder.CreateAgent(logger)
-	if err != nil {
-		logger.Fatal("Unable to initialize Jaeger Agent", zap.Error(err))
-	}
-
-	logger.Info("Starting agent")
-	if err := agent.Run(); err != nil {
-		logger.Fatal("Failed to run the agent", zap.Error(err))
-	}
-	select {}
-}
+// Package metrics provides command line flags for configuring the metrics backend.
+package metrics


### PR DESCRIPTION
Defaults to expvar. Prometheus metrics currently don't work because
it does not allow dots in the names (https://github.com/uber/jaeger-lib/issues/20)
and requires pre-declaring all tag keys, which is not supported by
the Jaeger's metrics API.

Re: https://github.com/uber/jaeger/issues/273