### PR TITLE
Added liveness and readiness checks to collector and query

### DIFF
--- a/cmd/collector/app/builder/builder_flags.go
+++ b/cmd/collector/app/builder/builder_flags.go
@@ -30,12 +30,13 @@ import (
 )
 
 const (
-	collectorQueueSize     = "collector.queue-size"
-	collectorNumWorkers    = "collector.num-workers"
-	collectorWriteCacheTTL = "collector.write-cache-ttl"
-	collectorPort          = "collector.port"
-	collectorHTTPPort      = "collector.http-port"
-	collectorZipkinHTTPort = "collector.zipkin.http-port"
+	collectorQueueSize           = "collector.queue-size"
+	collectorNumWorkers          = "collector.num-workers"
+	collectorWriteCacheTTL       = "collector.write-cache-ttl"
+	collectorPort                = "collector.port"
+	collectorHTTPPort            = "collector.http-port"
+	collectorZipkinHTTPort       = "collector.zipkin.http-port"
+	collectorHealthCheckHTTPPort = "collector.health-check-http-port"
 )
 
 // CollectorOptions holds configuration for collector
@@ -52,6 +53,8 @@ type CollectorOptions struct {
 	CollectorHTTPPort int
 	// CollectorZipkinHTTPPort is the port that the Zipkin collector service listens in on for http requests
 	CollectorZipkinHTTPPort int
+	// CollectorHealthCheckHTTPPort is the port that the health check service listens in on for http requests
+	CollectorHealthCheckHTTPPort int
 }
 
 // AddFlags adds flags for CollectorOptions
@@ -62,6 +65,7 @@ func AddFlags(flags *flag.FlagSet) {
 	flags.Int(collectorPort, 14267, "The tchannel port for the collector service")
 	flags.Int(collectorHTTPPort, 14268, "The http port for the collector service")
 	flags.Int(collectorZipkinHTTPort, 0, "The http port for the Zipkin collector service e.g. 9411")
+	flags.Int(collectorHealthCheckHTTPPort, 14269, "The http port for the health check service")
 }
 
 // InitFromViper initializes CollectorOptions with properties from viper
@@ -72,5 +76,6 @@ func (cOpts *CollectorOptions) InitFromViper(v *viper.Viper) *CollectorOptions {
 	cOpts.CollectorPort = v.GetInt(collectorPort)
 	cOpts.CollectorHTTPPort = v.GetInt(collectorHTTPPort)
 	cOpts.CollectorZipkinHTTPPort = v.GetInt(collectorZipkinHTTPort)
+	cOpts.CollectorHealthCheckHTTPPort = v.GetInt(collectorHealthCheckHTTPPort)
 	return cOpts
 }

--- a/cmd/query/app/builder/builder_flags.go
+++ b/cmd/query/app/builder/builder_flags.go
@@ -27,9 +27,10 @@ import (
 )
 
 const (
-	queryPort        = "query.port"
-	queryPrefix      = "query.prefix"
-	queryStaticFiles = "query.static-files"
+	queryPort                = "query.port"
+	queryPrefix              = "query.prefix"
+	queryStaticFiles         = "query.static-files"
+	queryHealthCheckHTTPPort = "query.health-check-http-port"
 )
 
 // QueryOptions holds configuration for query
@@ -40,6 +41,8 @@ type QueryOptions struct {
 	QueryPrefix string
 	// QueryStaticAssets is the path for the static assets for the UI (https://github.com/uber/jaeger-ui)
 	QueryStaticAssets string
+	// QueryHealthCheckHTTPPort is the port that the health check service listens in on for http requests
+	QueryHealthCheckHTTPPort int
 }
 
 // AddFlags adds flags for QueryOptions
@@ -47,6 +50,7 @@ func AddFlags(flagSet *flag.FlagSet) {
 	flagSet.Int(queryPort, 16686, "The port for the query service")
 	flagSet.String(queryPrefix, "api", "The prefix for the url of the query service")
 	flagSet.String(queryStaticFiles, "jaeger-ui-build/build/", "The path for the static assets for the UI")
+	flagSet.Int(queryHealthCheckHTTPPort, 16687, "The http port for the health check service")
 }
 
 // InitFromViper initializes QueryOptions with properties from viper
@@ -54,5 +58,6 @@ func (qOpts *QueryOptions) InitFromViper(v *viper.Viper) *QueryOptions {
 	qOpts.QueryPort = v.GetInt(queryPort)
 	qOpts.QueryPrefix = v.GetString(queryPrefix)
 	qOpts.QueryStaticAssets = v.GetString(queryStaticFiles)
+	qOpts.QueryHealthCheckHTTPPort = v.GetInt(queryHealthCheckHTTPPort)
 	return qOpts
 }

--- a/pkg/healthcheck/handler.go
+++ b/pkg/healthcheck/handler.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package healthcheck
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+
+	"go.uber.org/zap"
+)
+
+// State represents the current health check state
+type State struct {
+	state   int
+	logger  *zap.Logger
+	onClose chan struct{}
+}
+
+// Serve requests on the specified port. The initial state is what's specified with the state parameter
+func Serve(state int, port int, logger *zap.Logger) (*State, error) {
+	hs, err := NewState(state, logger)
+	handler, err := NewHandler(hs)
+
+	s := &http.Server{Handler: handler}
+	portStr := ":" + strconv.Itoa(port)
+	l, err := net.Listen("tcp", portStr)
+	if err != nil {
+		logger.Error("failed to listen", zap.Error(err))
+		return nil, err
+	}
+	ServeWithListener(l, s, logger)
+
+	hs.logger.Info("Health Check server started", zap.Int("http-port", port))
+
+	return hs, err
+}
+
+// NewState creates a new state instance. The initial state is what's specified with the state parameter
+func NewState(state int, logger *zap.Logger) (*State, error) {
+	s := &State{state: state, logger: logger}
+	return s, nil
+}
+
+// NewHandler creates a new HTTP handler using the given state as source of information
+func NewHandler(s *State) (http.Handler, error) {
+	mu := http.NewServeMux()
+	mu.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(s.state)
+
+		// this is written only for response with an entity, so, it won't be used for a 204 - No content
+		w.Write([]byte("Server not available"))
+	})
+	return mu, nil
+}
+
+// ServeWithListener starts a new HTTP server on the given port and with the provided handler
+func ServeWithListener(l net.Listener, s *http.Server, logger *zap.Logger) (*http.Server, error) {
+	go func() {
+		if err := s.Serve(l); err != nil {
+			logger.Error("failed to serve", zap.Error(err))
+		}
+	}()
+
+	return s, nil
+}
+
+// Ready updates the current state to the "ready" state, translated as a 2xx-class HTTP status code
+func (s *State) Ready() {
+	s.Set(http.StatusNoContent)
+}
+
+// Set a new HTTP status for the health check
+func (s *State) Set(state int) {
+	s.state = state
+	s.logger.Info("Health Check state change", zap.Int("http-port", s.state))
+}
+
+// Get the current status code for this health check
+func (s *State) Get() int {
+	return s.state
+}

--- a/pkg/healthcheck/handler_test.go
+++ b/pkg/healthcheck/handler_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package healthcheck_test
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/jaeger/pkg/healthcheck"
+	"go.uber.org/zap"
+)
+
+func TestProperInitialState(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	s, err := healthcheck.NewState(http.StatusServiceUnavailable, logger)
+	if err != nil {
+		t.Error("Could not start the health check server.", zap.Error(err))
+	}
+
+	if http.StatusServiceUnavailable != s.Get() {
+		t.Errorf("Expected another handler state. Is: %d, expected: %d", s.Get(), http.StatusServiceUnavailable)
+	}
+}
+
+func TestChangedState(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	s, err := healthcheck.NewState(http.StatusServiceUnavailable, logger)
+	if err != nil {
+		t.Error("Could not start the health check server.", zap.Error(err))
+	}
+	s.Set(http.StatusInternalServerError)
+
+	if http.StatusInternalServerError != s.Get() {
+		t.Errorf("Expected another handler state. Is: %d, expected: %d", s.Get(), http.StatusInternalServerError)
+	}
+}
+
+func TestStateIsReady(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	s, err := healthcheck.NewState(http.StatusServiceUnavailable, logger)
+	if err != nil {
+		t.Error("Could not start the health check server.", zap.Error(err))
+	}
+	s.Ready()
+
+	if http.StatusNoContent != s.Get() {
+		t.Errorf("Expected another handler state. Is: %d, expected: %d", s.Get(), http.StatusNoContent)
+	}
+}
+
+func TestPortBusy(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	l, err := net.Listen("tcp", ":0")
+	defer l.Close()
+	if err != nil {
+		t.Error("Could not start on a random port.", zap.Error(err))
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+
+	_, err = healthcheck.Serve(http.StatusServiceUnavailable, port, logger)
+	if err == nil {
+		t.Error("We expected an error on trying to serve on a non-free port.", zap.Error(err))
+	}
+}
+
+func TestHttpCall(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	state, err := healthcheck.NewState(http.StatusServiceUnavailable, logger)
+	handler, err := healthcheck.NewHandler(state)
+	if err != nil {
+		t.Error("Could not start the health check server.", zap.Error(err))
+	}
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	state.Ready()
+
+	resp, err := http.Get(server.URL + "/")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestListenerClose(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	state, err := healthcheck.NewState(http.StatusServiceUnavailable, logger)
+	handler, err := healthcheck.NewHandler(state)
+	if err != nil {
+		t.Error("Could not start the health check server.", zap.Error(err))
+	}
+
+	s := &http.Server{Handler: handler}
+	l, err := net.Listen("tcp", ":0")
+	defer l.Close()
+	s, err = healthcheck.ServeWithListener(l, s, logger)
+}
+
+func TestServeHandler(t *testing.T) {
+	healthcheck.Serve(http.StatusServiceUnavailable, 0, zap.NewNop())
+}


### PR DESCRIPTION
The idea of this PR is to create a first version of the readiness and liveness checks. It can be improved in the future to expose the metrics from `expvar`, so that an orchestration service can auto scale based on the data reported by this.

Similarly, this would allow the server to keep booted even if the underlying data store is offline: while the main HTTP port might still accept incoming requests and put on a buffer, the health check endpoint might return a `degraded` state, so that admins could get notified if something is wrong.

Sample output for "ready and alive":
```
curl -v http://localhost:17686/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 17686 (#0)
> GET / HTTP/1.1
> Host: localhost:17686
> User-Agent: curl/7.53.1
> Accept: */*
> 
< HTTP/1.1 204 No Content
< Date: Thu, 20 Jul 2017 12:18:20 GMT
< 
* Connection #0 to host localhost left intact
```

Sample output for "booted, but in trouble" (ie: not passing liveness check):
```
curl -v http://localhost:15268/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 15268 (#0)
> GET / HTTP/1.1
> Host: localhost:15268
> User-Agent: curl/7.53.1
> Accept: */*
> 
< HTTP/1.1 500 Internal Server Error
< Date: Thu, 20 Jul 2017 12:19:38 GMT
< Content-Length: 20
< Content-Type: text/plain; charset=utf-8
< 
* Connection #0 to host localhost left intact
Server not available
```

Sample output for "booting" (ie: not passing readiness check):
```
curl -v http://localhost:15268/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 15268 (#0)
> GET / HTTP/1.1
> Host: localhost:15268
> User-Agent: curl/7.53.1
> Accept: */*
> 
< HTTP/1.1 503 Service Unavailable
< Date: Thu, 20 Jul 2017 12:20:12 GMT
< Content-Length: 20
< Content-Type: text/plain; charset=utf-8
< 
* Connection #0 to host localhost left intact
Server not available
```