### PR TITLE
Cobra viper configuration keep it simple

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -21,9 +21,7 @@
 package main
 
 import (
-	"flag"
 	"runtime"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -31,6 +29,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/uber/jaeger/cmd/agent/app"
+	"github.com/uber/jaeger/pkg/config"
 	"github.com/uber/jaeger/pkg/metrics"
 )
 
@@ -62,14 +61,12 @@ func main() {
 		},
 	}
 
-	flags := &flag.FlagSet{}
-	app.AddFlags(flags)
-	metrics.AddFlags(flags)
-	command.PersistentFlags().AddGoFlagSet(flags)
-
-	v.BindPFlags(command.PersistentFlags())
-	v.AutomaticEnv()
-	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+	config.AddFlags(
+		v,
+		command,
+		app.AddFlags,
+		metrics.AddFlags,
+	)
 
 	if err := command.Execute(); err != nil {
 		logger.Fatal("agent command failed", zap.Error(err))

--- a/cmd/collector/app/builder/builder_flags.go
+++ b/cmd/collector/app/builder/builder_flags.go
@@ -24,20 +24,53 @@ import (
 	"flag"
 	"time"
 
+	"github.com/spf13/viper"
+
 	"github.com/uber/jaeger/cmd/collector/app"
 )
 
-var (
-	// QueueSize is the size of collector's queue
-	QueueSize = flag.Int("collector.queue-size", app.DefaultQueueSize, "The queue size of the collector")
-	// NumWorkers is the number of internal workers in a collector
-	NumWorkers = flag.Int("collector.num-workers", app.DefaultNumWorkers, "The number of workers pulling items from the queue")
-	// WriteCacheTTL denotes how often to check and re-write a service or operation name
-	WriteCacheTTL = flag.Duration("collector.write-cache-ttl", time.Hour*12, "The duration to wait before rewriting an existing service or operation name")
-	// CollectorPort is the port that the collector service listens in on for tchannel requests
-	CollectorPort = flag.Int("collector.port", 14267, "The tchannel port for the collector service")
-	// CollectorHTTPPort is the port that the collector service listens in on for http requests
-	CollectorHTTPPort = flag.Int("collector.http-port", 14268, "The http port for the collector service")
-	// CollectorZipkinHTTPPort is the port that the Zipkin collector service listens in on for http requests
-	CollectorZipkinHTTPPort = flag.Int("collector.zipkin.http-port", 0, "The http port for the Zipkin collector service e.g. 9411")
+const (
+	collectorQueueSize     = "collector.queue-size"
+	collectorNumWorkers    = "collector.num-workers"
+	collectorWriteCacheTTL = "collector.write-cache-ttl"
+	collectorPort          = "collector.port"
+	collectorHTTPPort      = "collector.http-port"
+	collectorZipkinHTTPort = "collector.zipkin.http-port"
 )
+
+// CollectorOptions holds configuration for collector
+type CollectorOptions struct {
+	// QueueSize is the size of collector's queue
+	QueueSize int
+	// NumWorkers is the number of internal workers in a collector
+	NumWorkers int
+	// WriteCacheTTL denotes how often to check and re-write a service or operation name
+	WriteCacheTTL time.Duration
+	// CollectorPort is the port that the collector service listens in on for tchannel requests
+	CollectorPort int
+	// CollectorHTTPPort is the port that the collector service listens in on for http requests
+	CollectorHTTPPort int
+	// CollectorZipkinHTTPPort is the port that the Zipkin collector service listens in on for http requests
+	CollectorZipkinHTTPPort int
+}
+
+// AddFlags adds flags for CollectorOptions
+func AddFlags(flags *flag.FlagSet) {
+	flags.Int(collectorQueueSize, app.DefaultQueueSize, "The queue size of the collector")
+	flags.Int(collectorNumWorkers, app.DefaultNumWorkers, "The number of workers pulling items from the queue")
+	flags.Duration(collectorWriteCacheTTL, time.Hour*12, "The duration to wait before rewriting an existing service or operation name")
+	flags.Int(collectorPort, 14267, "The tchannel port for the collector service")
+	flags.Int(collectorHTTPPort, 14268, "The http port for the collector service")
+	flags.Int(collectorZipkinHTTPort, 0, "The http port for the Zipkin collector service e.g. 9411")
+}
+
+// InitFromViper initializes CollectorOptions with properties from viper
+func (cOpts *CollectorOptions) InitFromViper(v *viper.Viper) *CollectorOptions {
+	cOpts.QueueSize = v.GetInt(collectorQueueSize)
+	cOpts.NumWorkers = v.GetInt(collectorNumWorkers)
+	cOpts.WriteCacheTTL = v.GetDuration(collectorWriteCacheTTL)
+	cOpts.CollectorPort = v.GetInt(collectorPort)
+	cOpts.CollectorHTTPPort = v.GetInt(collectorHTTPPort)
+	cOpts.CollectorZipkinHTTPPort = v.GetInt(collectorZipkinHTTPort)
+	return cOpts
+}

--- a/cmd/collector/app/builder/span_handler_builder.go
+++ b/cmd/collector/app/builder/span_handler_builder.go
@@ -90,41 +90,38 @@ func NewSpanHandlerBuilder(cOpts *CollectorOptions, sFlags *flags.SharedFlags, o
 }
 
 func (spanHb *SpanHandlerBuilder) initCassStore(config cascfg.SessionBuilder) func() (spanstore.Writer, error) {
-	session, err := config.NewSession()
-	if err != nil {
-		return func() (spanstore.Writer, error) {
+	return func() (spanstore.Writer, error) {
+		session, err := config.NewSession()
+		if err != nil {
 			return nil, err
 		}
-	}
 
-	store := casSpanstore.NewSpanWriter(
-		session,
-		spanHb.collectorOpts.WriteCacheTTL,
-		spanHb.metricsFactory,
-		spanHb.logger,
-	)
-	return func() (spanstore.Writer, error) {
+		store := casSpanstore.NewSpanWriter(
+			session,
+			spanHb.collectorOpts.WriteCacheTTL,
+			spanHb.metricsFactory,
+			spanHb.logger,
+		)
+
 		return store, nil
 	}
 }
 
 func (spanHb *SpanHandlerBuilder) initElasticStore(esBuilder escfg.ClientBuilder) func() (spanstore.Writer, error) {
-	client, err := esBuilder.NewClient()
-	if err != nil {
-		return func() (spanstore.Writer, error) {
+	return func() (spanstore.Writer, error) {
+		client, err := esBuilder.NewClient()
+		if err != nil {
 			return nil, err
 		}
-	}
 
-	spanStore := esSpanstore.NewSpanWriter(
-		client,
-		spanHb.logger,
-		spanHb.metricsFactory,
-		esBuilder.GetNumShards(),
-		esBuilder.GetNumReplicas(),
-	)
+		spanStore := esSpanstore.NewSpanWriter(
+			client,
+			spanHb.logger,
+			spanHb.metricsFactory,
+			esBuilder.GetNumShards(),
+			esBuilder.GetNumReplicas(),
+		)
 
-	return func() (spanstore.Writer, error) {
 		return spanStore, nil
 	}
 }

--- a/cmd/collector/app/builder/span_handler_builder.go
+++ b/cmd/collector/app/builder/span_handler_builder.go
@@ -32,14 +32,11 @@ import (
 	zs "github.com/uber/jaeger/cmd/collector/app/sanitizer/zipkin"
 	"github.com/uber/jaeger/cmd/flags"
 	"github.com/uber/jaeger/model"
-	"github.com/uber/jaeger/pkg/cassandra"
 	cascfg "github.com/uber/jaeger/pkg/cassandra/config"
-	"github.com/uber/jaeger/pkg/es"
 	escfg "github.com/uber/jaeger/pkg/es/config"
 	casSpanstore "github.com/uber/jaeger/plugin/storage/cassandra/spanstore"
 	esSpanstore "github.com/uber/jaeger/plugin/storage/es/spanstore"
 	"github.com/uber/jaeger/storage/spanstore"
-	"github.com/uber/jaeger/storage/spanstore/memory"
 )
 
 var (
@@ -48,163 +45,120 @@ var (
 	errMissingElasticSearchConfig = errors.New("ElasticSearch not configured")
 )
 
-// SpanHandlerBuilder builds span (Jaeger and zipkin) handlers
-type SpanHandlerBuilder interface {
-	BuildHandlers() (app.ZipkinSpansHandler, app.JaegerBatchesHandler, error)
+// SpanHandlerBuilder holds configuration required for handlers
+type SpanHandlerBuilder struct {
+	logger         *zap.Logger
+	metricsFactory metrics.Factory
+	collectorOpts  *CollectorOptions
+	storageBuilder storageBuilder
 }
 
-// NewSpanHandlerBuilder returns a span handler
-func NewSpanHandlerBuilder(opts ...basicB.Option) (SpanHandlerBuilder, error) {
+type storageBuilder func() (spanstore.Writer, error)
+
+// NewSpanHandlerBuilder returns new SpanHandlerBuilder with configured span storage.
+func NewSpanHandlerBuilder(cOpts *CollectorOptions, sFlags *flags.SharedFlags, opts ...basicB.Option) (*SpanHandlerBuilder, error) {
 	options := basicB.ApplyOptions(opts...)
-	if flags.SpanStorage.Type == flags.CassandraStorageType {
+
+	spanHb := &SpanHandlerBuilder{
+		collectorOpts:  cOpts,
+		logger:         options.Logger,
+		metricsFactory: options.MetricsFactory,
+	}
+
+	if sFlags.SpanStorage.Type == flags.CassandraStorageType {
 		if options.Cassandra == nil {
 			return nil, errMissingCassandraConfig
 		}
-		return newCassandraBuilder(options.Cassandra, options.Logger, options.MetricsFactory), nil
-	} else if flags.SpanStorage.Type == flags.MemoryStorageType {
+		spanHb.storageBuilder = spanHb.initCassStore(options.Cassandra)
+	} else if sFlags.SpanStorage.Type == flags.MemoryStorageType {
 		if options.MemoryStore == nil {
 			return nil, errMissingMemoryStore
 		}
-		return newMemoryStoreBuilder(options.MemoryStore, options.Logger, options.MetricsFactory), nil
-	} else if flags.SpanStorage.Type == flags.ESStorageType {
+		spanHb.storageBuilder = func() (spanstore.Writer, error) {
+			return options.MemoryStore, nil
+		}
+	} else if sFlags.SpanStorage.Type == flags.ESStorageType {
 		if options.ElasticSearch == nil {
 			return nil, errMissingElasticSearchConfig
 		}
-		return newESBuilder(options.ElasticSearch, options.Logger, options.MetricsFactory), nil
+		spanHb.storageBuilder = spanHb.initElasticStore(options.ElasticSearch)
+	} else {
+		return nil, flags.ErrUnsupportedStorageType
 	}
-	return nil, flags.ErrUnsupportedStorageType
+
+	return spanHb, nil
 }
 
-type memoryStoreBuilder struct {
-	logger         *zap.Logger
-	metricsFactory metrics.Factory
-	memStore       *memory.Store
-}
-
-func newMemoryStoreBuilder(memStore *memory.Store, logger *zap.Logger, metricsFactory metrics.Factory) *memoryStoreBuilder {
-	return &memoryStoreBuilder{
-		logger:         logger,
-		metricsFactory: metricsFactory,
-		memStore:       memStore,
+func (spanHb *SpanHandlerBuilder) initCassStore(config cascfg.SessionBuilder) func() (spanstore.Writer, error) {
+	session, err := config.NewSession()
+	if err != nil {
+		return func() (spanstore.Writer, error) {
+			return nil, err
+		}
 	}
-}
 
-func (m *memoryStoreBuilder) BuildHandlers() (app.ZipkinSpansHandler, app.JaegerBatchesHandler, error) {
-	return buildHandlers(m.memStore, m.logger, m.metricsFactory)
-}
-
-type cassandraSpanHandlerBuilder struct {
-	logger         *zap.Logger
-	metricsFactory metrics.Factory
-	configuration  cascfg.Configuration
-	session        cassandra.Session
-}
-
-func newCassandraBuilder(config *cascfg.Configuration, logger *zap.Logger, metricsFactory metrics.Factory) *cassandraSpanHandlerBuilder {
-	return &cassandraSpanHandlerBuilder{
-		logger:         logger,
-		metricsFactory: metricsFactory,
-		configuration:  fixConfiguration(*config),
+	store := casSpanstore.NewSpanWriter(
+		session,
+		spanHb.collectorOpts.WriteCacheTTL,
+		spanHb.metricsFactory,
+		spanHb.logger,
+	)
+	return func() (spanstore.Writer, error) {
+		return store, nil
 	}
 }
 
-func (c *cassandraSpanHandlerBuilder) BuildHandlers() (app.ZipkinSpansHandler, app.JaegerBatchesHandler, error) {
-	session, err := c.getSession()
+func (spanHb *SpanHandlerBuilder) initElasticStore(esBuilder escfg.ClientBuilder) func() (spanstore.Writer, error) {
+	client, err := esBuilder.NewClient()
+	if err != nil {
+		return func() (spanstore.Writer, error) {
+			return nil, err
+		}
+	}
+
+	spanStore := esSpanstore.NewSpanWriter(
+		client,
+		spanHb.logger,
+		spanHb.metricsFactory,
+		esBuilder.GetNumShards(),
+		esBuilder.GetNumReplicas(),
+	)
+
+	return func() (spanstore.Writer, error) {
+		return spanStore, nil
+	}
+}
+
+// BuildHandlers builds span handlers (Zipkin, Jaeger)
+func (spanHb *SpanHandlerBuilder) BuildHandlers() (app.ZipkinSpansHandler, app.JaegerBatchesHandler, error) {
+	hostname, _ := os.Hostname()
+	hostMetrics := spanHb.metricsFactory.Namespace(hostname, nil)
+
+	zSanitizer := zs.NewChainedSanitizer(
+		zs.NewSpanDurationSanitizer(spanHb.logger),
+		zs.NewParentIDSanitizer(spanHb.logger),
+	)
+
+	spanWriter, err := spanHb.storageBuilder()
 	if err != nil {
 		return nil, nil, err
 	}
-	spanStore := casSpanstore.NewSpanWriter(
-		session,
-		*WriteCacheTTL,
-		c.metricsFactory,
-		c.logger,
+
+	spanProcessor := app.NewSpanProcessor(
+		spanWriter,
+		app.Options.ServiceMetrics(spanHb.metricsFactory),
+		app.Options.HostMetrics(hostMetrics),
+		app.Options.Logger(spanHb.logger),
+		app.Options.SpanFilter(defaultSpanFilter),
+		app.Options.NumWorkers(spanHb.collectorOpts.NumWorkers),
+		app.Options.QueueSize(spanHb.collectorOpts.QueueSize),
 	)
 
-	return buildHandlers(spanStore, c.logger, c.metricsFactory)
+	return app.NewZipkinSpanHandler(spanHb.logger, spanProcessor, zSanitizer),
+		app.NewJaegerSpanHandler(spanHb.logger, spanProcessor),
+		nil
 }
 
 func defaultSpanFilter(*model.Span) bool {
 	return true
-}
-
-func (c *cassandraSpanHandlerBuilder) getSession() (cassandra.Session, error) {
-	if c.session == nil {
-		session, err := c.configuration.NewSession()
-		c.session = session
-		return c.session, err
-	}
-	return c.session, nil
-}
-
-func fixConfiguration(config cascfg.Configuration) cascfg.Configuration {
-	config.ProtoVersion = 4
-	return config
-}
-
-type esSpanHandlerBuilder struct {
-	logger         *zap.Logger
-	client         es.Client
-	metricsFactory metrics.Factory
-	configuration  escfg.Configuration
-}
-
-func newESBuilder(config *escfg.Configuration, logger *zap.Logger, metricsFactory metrics.Factory) *esSpanHandlerBuilder {
-	return &esSpanHandlerBuilder{
-		configuration:  *config,
-		metricsFactory: metricsFactory,
-		logger:         logger,
-	}
-}
-
-func (e *esSpanHandlerBuilder) BuildHandlers() (app.ZipkinSpansHandler, app.JaegerBatchesHandler, error) {
-	client, err := e.getClient()
-	if err != nil {
-		return nil, nil, err
-	}
-	spanStore := esSpanstore.NewSpanWriter(
-		client,
-		e.logger,
-		e.metricsFactory,
-		e.configuration.NumShards,
-		e.configuration.NumReplicas,
-	)
-
-	return buildHandlers(spanStore, e.logger, e.metricsFactory)
-}
-
-func (e *esSpanHandlerBuilder) getClient() (es.Client, error) {
-	if e.client == nil {
-		client, err := e.configuration.NewClient()
-		e.client = client
-		return e.client, err
-	}
-	return e.client, nil
-}
-
-func buildHandlers(
-	spanStore spanstore.Writer,
-	logger *zap.Logger,
-	metricsFactory metrics.Factory,
-) (app.ZipkinSpansHandler, app.JaegerBatchesHandler, error) {
-	hostname, _ := os.Hostname()
-	hostMetrics := metricsFactory.Namespace(hostname, nil)
-
-	zSanitizer := zs.NewChainedSanitizer(
-		zs.NewSpanDurationSanitizer(logger),
-		zs.NewParentIDSanitizer(logger),
-	)
-
-	spanProcessor := app.NewSpanProcessor(
-		spanStore,
-		app.Options.ServiceMetrics(metricsFactory),
-		app.Options.HostMetrics(hostMetrics),
-		app.Options.Logger(logger),
-		app.Options.SpanFilter(defaultSpanFilter),
-		app.Options.NumWorkers(*NumWorkers),
-		app.Options.QueueSize(*QueueSize),
-	)
-
-	return app.NewZipkinSpanHandler(logger, spanProcessor, zSanitizer),
-		app.NewJaegerSpanHandler(logger, spanProcessor),
-		nil
 }

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -30,9 +30,6 @@ import (
 	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics/go-kit"
 	"github.com/uber/jaeger-lib/metrics/go-kit/expvar"
-	"github.com/uber/jaeger/pkg/recoveryhandler"
-	jc "github.com/uber/jaeger/thrift-gen/jaeger"
-	zc "github.com/uber/jaeger/thrift-gen/zipkincore"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/thrift"
 	"go.uber.org/zap"
@@ -44,6 +41,9 @@ import (
 	"github.com/uber/jaeger/cmd/flags"
 	casFlags "github.com/uber/jaeger/cmd/flags/cassandra"
 	"github.com/uber/jaeger/pkg/config"
+	"github.com/uber/jaeger/pkg/recoveryhandler"
+	jc "github.com/uber/jaeger/thrift-gen/jaeger"
+	zc "github.com/uber/jaeger/thrift-gen/zipkincore"
 )
 
 func main() {

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -21,87 +21,118 @@
 package main
 
 import (
-	"flag"
 	"net"
 	"net/http"
 	"strconv"
 
 	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/uber/jaeger-lib/metrics/go-kit"
+	"github.com/uber/jaeger-lib/metrics/go-kit/expvar"
 	"github.com/uber/jaeger/pkg/recoveryhandler"
+	jc "github.com/uber/jaeger/thrift-gen/jaeger"
+	zc "github.com/uber/jaeger/thrift-gen/zipkincore"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/thrift"
 	"go.uber.org/zap"
-
-	"github.com/uber/jaeger-lib/metrics/go-kit"
-	"github.com/uber/jaeger-lib/metrics/go-kit/expvar"
-	jc "github.com/uber/jaeger/thrift-gen/jaeger"
-	zc "github.com/uber/jaeger/thrift-gen/zipkincore"
 
 	basicB "github.com/uber/jaeger/cmd/builder"
 	"github.com/uber/jaeger/cmd/collector/app"
 	"github.com/uber/jaeger/cmd/collector/app/builder"
 	"github.com/uber/jaeger/cmd/collector/app/zipkin"
+	"github.com/uber/jaeger/cmd/flags"
 	casFlags "github.com/uber/jaeger/cmd/flags/cassandra"
-)
-
-const (
-	serviceName = "jaeger-collector"
+	"github.com/uber/jaeger/pkg/config"
 )
 
 func main() {
-	casOptions := casFlags.NewOptions()
-	casOptions.Bind(flag.CommandLine, "cassandra")
-	flag.Parse()
 	logger, _ := zap.NewProduction()
-	baseMetrics := xkit.Wrap(serviceName, expvar.NewFactory(10))
+	serviceName := "jaeger-collector"
+	casOptions := casFlags.NewOptions("cassandra")
 
-	spanBuilder, err := builder.NewSpanHandlerBuilder(
-		basicB.Options.CassandraOption(casOptions.GetPrimary()),
-		basicB.Options.LoggerOption(logger),
-		basicB.Options.MetricsFactoryOption(baseMetrics),
+	v := viper.New()
+	command := &cobra.Command{
+		Use:   "jaeger-collector",
+		Short: "Jaeger collector receives and processes traces from Jaeger agents and clients",
+		Long: `Jaeger collector receives traces from Jaeger agents and agent and runs them through
+				a processing pipeline.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			casOptions.InitFromViper(v)
+
+			baseMetrics := xkit.Wrap(serviceName, expvar.NewFactory(10))
+
+			builderOpts := new(builder.CollectorOptions).InitFromViper(v)
+			sFlags := new(flags.SharedFlags).InitFromViper(v)
+			handlerBuilder, err := builder.NewSpanHandlerBuilder(
+				builderOpts,
+				sFlags,
+				basicB.Options.CassandraOption(casOptions.GetPrimary()),
+				basicB.Options.LoggerOption(logger),
+				basicB.Options.MetricsFactoryOption(baseMetrics),
+			)
+			if err != nil {
+				logger.Fatal("Unable to set up builder", zap.Error(err))
+			}
+			zipkinSpansHandler, jaegerBatchesHandler, err := handlerBuilder.BuildHandlers()
+			if err != nil {
+				logger.Fatal("Unable to build span handlers", zap.Error(err))
+			}
+
+			ch, err := tchannel.NewChannel(serviceName, &tchannel.ChannelOptions{})
+			if err != nil {
+				logger.Fatal("Unable to create new TChannel", zap.Error(err))
+			}
+			server := thrift.NewServer(ch)
+			server.Register(jc.NewTChanCollectorServer(jaegerBatchesHandler))
+			server.Register(zc.NewTChanZipkinCollectorServer(zipkinSpansHandler))
+
+			portStr := ":" + strconv.Itoa(builderOpts.CollectorPort)
+			listener, err := net.Listen("tcp", portStr)
+			if err != nil {
+				logger.Fatal("Unable to start listening on channel", zap.Error(err))
+			}
+			ch.Serve(listener)
+
+			r := mux.NewRouter()
+			apiHandler := app.NewAPIHandler(jaegerBatchesHandler)
+			apiHandler.RegisterRoutes(r)
+			httpPortStr := ":" + strconv.Itoa(builderOpts.CollectorHTTPPort)
+			recoveryHandler := recoveryhandler.NewRecoveryHandler(logger, true)
+
+			go startZipkinHTTPAPI(logger, builderOpts.CollectorZipkinHTTPPort, zipkinSpansHandler, recoveryHandler)
+
+			logger.Info("Listening for HTTP traffic", zap.Int("http-port", builderOpts.CollectorHTTPPort))
+			if err := http.ListenAndServe(httpPortStr, recoveryHandler(r)); err != nil {
+				logger.Fatal("Could not launch service", zap.Error(err))
+			}
+		},
+	}
+
+	config.AddFlags(
+		v,
+		command,
+		flags.AddFlags,
+		builder.AddFlags,
+		casOptions.AddFlags,
 	)
-	if err != nil {
-		logger.Fatal("Unable to set up builder", zap.Error(err))
-	}
-	zipkinSpansHandler, jaegerBatchesHandler, err := spanBuilder.BuildHandlers()
-	if err != nil {
-		logger.Fatal("Unable to build span handlers", zap.Error(err))
-	}
 
-	ch, err := tchannel.NewChannel(serviceName, &tchannel.ChannelOptions{})
-	if err != nil {
-		logger.Fatal("Unable to create new TChannel", zap.Error(err))
-	}
-	server := thrift.NewServer(ch)
-	server.Register(jc.NewTChanCollectorServer(jaegerBatchesHandler))
-	server.Register(zc.NewTChanZipkinCollectorServer(zipkinSpansHandler))
-
-	portStr := ":" + strconv.Itoa(*builder.CollectorPort)
-	listener, err := net.Listen("tcp", portStr)
-	if err != nil {
-		logger.Fatal("Unable to start listening on channel", zap.Error(err))
-	}
-	ch.Serve(listener)
-
-	r := mux.NewRouter()
-	app.NewAPIHandler(jaegerBatchesHandler).RegisterRoutes(r)
-	httpPortStr := ":" + strconv.Itoa(*builder.CollectorHTTPPort)
-	recoveryHandler := recoveryhandler.NewRecoveryHandler(logger, true)
-
-	go startZipkinHTTPAPI(logger, zipkinSpansHandler, recoveryHandler)
-
-	logger.Info("Listening for HTTP traffic", zap.Int("http-port", *builder.CollectorHTTPPort))
-	if err := http.ListenAndServe(httpPortStr, recoveryHandler(r)); err != nil {
-		logger.Fatal("Could not launch service", zap.Error(err))
+	if error := command.Execute(); error != nil {
+		logger.Fatal(error.Error())
 	}
 }
 
-func startZipkinHTTPAPI(logger *zap.Logger, zipkinSpansHandler app.ZipkinSpansHandler, recoveryHandler func(http.Handler) http.Handler) {
-	if *builder.CollectorZipkinHTTPPort != 0 {
+func startZipkinHTTPAPI(
+	logger *zap.Logger,
+	zipkinPort int,
+	zipkinSpansHandler app.ZipkinSpansHandler,
+	recoveryHandler func(http.Handler) http.Handler,
+) {
+	if zipkinPort != 0 {
 		r := mux.NewRouter()
 		zipkin.NewAPIHandler(zipkinSpansHandler).RegisterRoutes(r)
-		httpPortStr := ":" + strconv.Itoa(*builder.CollectorZipkinHTTPPort)
-		logger.Info("Listening for Zipkin HTTP traffic", zap.Int("zipkin.http-port", *builder.CollectorZipkinHTTPPort))
+		httpPortStr := ":" + strconv.Itoa(zipkinPort)
+		logger.Info("Listening for Zipkin HTTP traffic", zap.Int("zipkin.http-port", zipkinPort))
 
 		if err := http.ListenAndServe(httpPortStr, recoveryHandler(r)); err != nil {
 			logger.Fatal("Could not launch service", zap.Error(err))

--- a/cmd/flags/cassandra/options_test.go
+++ b/cmd/flags/cassandra/options_test.go
@@ -21,13 +21,12 @@
 package cassandra
 
 import (
-	"flag"
 	"testing"
 	"time"
 
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/jaeger/pkg/config"
 )
 
 func TestOptions(t *testing.T) {
@@ -45,12 +44,7 @@ func TestOptions(t *testing.T) {
 
 func TestOptionsWithFlags(t *testing.T) {
 	opts := NewOptions("cas", "cas.aux")
-	v := viper.New()
-	command := &cobra.Command{}
-	flagSet := &flag.FlagSet{}
-	opts.AddFlags(flagSet)
-	command.PersistentFlags().AddGoFlagSet(flagSet)
-	v.BindPFlags(command.PersistentFlags())
+	v, command := config.Viperize(opts.AddFlags)
 	command.ParseFlags([]string{
 		"--cas.keyspace=jaeger",
 		"--cas.servers=1.1.1.1,2.2.2.2",
@@ -64,7 +58,6 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--cas.aux.keyspace=jaeger-archive",
 		"--cas.aux.servers=3.3.3.3,4.4.4.4",
 	})
-
 	opts.InitFromViper(v)
 
 	primary := opts.GetPrimary()

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -26,6 +26,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/spf13/viper"
 )
 
 const (
@@ -34,17 +36,41 @@ const (
 	// MemoryStorageType is the storage type flag denoting an in-memory store
 	MemoryStorageType = "memory"
 	// ESStorageType is the storage type flag denoting an ElasticSearch backing store
-	ESStorageType = "elasticsearch"
+	ESStorageType                  = "elasticsearch"
+	runtimeMetricsFrequency        = "runtime-metrics-frequency"
+	spanStorageType                = "span-storage.type"
+	logLevel                       = "log-level"
+	dependencyStorageType          = "dependency-storage.type"
+	dependencyStorageDataFrequency = "dependency-storage.data-frequency"
 )
+
+// SharedFlags holds flags configuration
+type SharedFlags struct {
+	// SpanStorage defines common settings for Span Storage.
+	SpanStorage spanStorage
+	// DependencyStorage defines common settings for Dependency Storage.
+	DependencyStorage dependencyStorage
+}
+
+// InitFromViper initializes SharedFlags with properties from viper
+func (flags *SharedFlags) InitFromViper(v *viper.Viper) *SharedFlags {
+	flags.SpanStorage.Type = v.GetString(spanStorageType)
+	flags.DependencyStorage.Type = v.GetString(dependencyStorageType)
+	flags.DependencyStorage.DataFrequency = v.GetDuration(dependencyStorageDataFrequency)
+	return flags
+}
+
+// AddFlags adds flags for SharedFlags
+func AddFlags(flagSet *flag.FlagSet) {
+	flagSet.Duration(runtimeMetricsFrequency, 1*time.Second, "The frequency of reporting Go runtime metrics")
+	flagSet.String(spanStorageType, CassandraStorageType, fmt.Sprintf("The type of span storage backend to use, options are currently [%v,%v]", CassandraStorageType, MemoryStorageType))
+	flagSet.String(logLevel, "info", "Minimal allowed log level")
+	flagSet.String(dependencyStorageType, CassandraStorageType, fmt.Sprintf("The type of dependency storage backend to use, options are currently [%v,%v]", CassandraStorageType, MemoryStorageType))
+	flagSet.Duration(dependencyStorageDataFrequency, time.Hour*24, "Frequency of service dependency calculations")
+}
 
 // ErrUnsupportedStorageType is the error when dealing with an unsupported storage type
 var ErrUnsupportedStorageType = errors.New("Storage Type is not supported")
-
-// SpanStorage defines common settings for Span Storage.
-var SpanStorage = spanStorage{}
-
-// DependencyStorage defines common settings for Dependency Storage.
-var DependencyStorage = dependencyStorage{}
 
 type logging struct {
 	Level string
@@ -70,11 +96,4 @@ type cassandraOptions struct {
 
 func (co cassandraOptions) ServerList() []string {
 	return strings.Split(co.Servers, ",")
-}
-
-func init() {
-	flag.StringVar(&SpanStorage.Type, "span-storage.type", CassandraStorageType, fmt.Sprintf("The type of span storage backend to use, options are currently [%v,%v]", CassandraStorageType, MemoryStorageType))
-
-	flag.StringVar(&DependencyStorage.Type, "dependency-storage.type", CassandraStorageType, fmt.Sprintf("The type of dependency storage backend to use, options are currently [%v,%v]", CassandraStorageType, MemoryStorageType))
-	flag.DurationVar(&DependencyStorage.DataFrequency, "dependency-storage.data-frequency", time.Hour*24, "Frequency of service dependency calculations")
 }

--- a/cmd/query/app/builder/builder_flags_test.go
+++ b/cmd/query/app/builder/builder_flags_test.go
@@ -21,9 +21,11 @@
 package builder
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/uber/jaeger/pkg/config"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/jaeger/pkg/config"
 )
 
 func TestQueryBuilderFlags(t *testing.T) {

--- a/cmd/query/app/builder/builder_flags_test.go
+++ b/cmd/query/app/builder/builder_flags_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package builder
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/jaeger/pkg/config"
+	"testing"
+)
+
+func TestQueryBuilderFlags(t *testing.T) {
+	v, command := config.Viperize(AddFlags)
+	command.ParseFlags([]string{"--query.static-files=/dev/null", "--query.prefix=api", "--query.port=80"})
+	qOpts := new(QueryOptions).InitFromViper(v)
+	assert.Equal(t, "/dev/null", qOpts.QueryStaticAssets)
+	assert.Equal(t, "api", qOpts.QueryPrefix)
+	assert.Equal(t, 80, qOpts.QueryPort)
+}

--- a/cmd/query/app/builder/cassandra.go
+++ b/cmd/query/app/builder/cassandra.go
@@ -26,7 +26,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/uber/jaeger-lib/metrics"
-	"github.com/uber/jaeger/cmd/flags"
 	"github.com/uber/jaeger/pkg/cassandra"
 	cascfg "github.com/uber/jaeger/pkg/cassandra/config"
 	cDependencyStore "github.com/uber/jaeger/plugin/storage/cassandra/dependencystore"
@@ -43,12 +42,12 @@ type cassandraBuilder struct {
 	dependencyDataFrequency time.Duration
 }
 
-func newCassandraBuilder(config *cascfg.Configuration, logger *zap.Logger, metricsFactory metrics.Factory) *cassandraBuilder {
+func newCassandraBuilder(config *cascfg.Configuration, logger *zap.Logger, metricsFactory metrics.Factory, dependencyDataFreq time.Duration) *cassandraBuilder {
 	cBuilder := &cassandraBuilder{
 		logger:                  logger,
 		metricsFactory:          metricsFactory,
 		configuration:           fixConfiguration(*config),
-		dependencyDataFrequency: flags.DependencyStorage.DataFrequency,
+		dependencyDataFrequency: dependencyDataFreq,
 	}
 	return cBuilder
 }

--- a/cmd/query/app/builder/cassandra_test.go
+++ b/cmd/query/app/builder/cassandra_test.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger/cmd/flags"
 	"github.com/uber/jaeger/pkg/cassandra/config"
 	"github.com/uber/jaeger/pkg/cassandra/mocks"
 )
@@ -35,7 +36,8 @@ func withBuilder(f func(builder *cassandraBuilder)) {
 	cfg := &config.Configuration{
 		Servers: []string{"127.0.0.1"},
 	}
-	cBuilder := newCassandraBuilder(cfg, zap.NewNop(), metrics.NullFactory)
+	sFlags := &flags.SharedFlags{}
+	cBuilder := newCassandraBuilder(cfg, zap.NewNop(), metrics.NullFactory, sFlags.DependencyStorage.DataFrequency)
 	f(cBuilder)
 }
 

--- a/cmd/query/app/builder/storage.go
+++ b/cmd/query/app/builder/storage.go
@@ -22,7 +22,7 @@ package builder
 
 import (
 	"errors"
-	"flag"
+	"time"
 
 	basicB "github.com/uber/jaeger/cmd/builder"
 	"github.com/uber/jaeger/cmd/flags"
@@ -43,22 +43,21 @@ var (
 )
 
 // NewStorageBuilder creates a StorageBuilder based off the flags that have been set
-func NewStorageBuilder(opts ...basicB.Option) (StorageBuilder, error) {
-	flag.Parse()
+func NewStorageBuilder(storageType string, dependencyDataFreq time.Duration, opts ...basicB.Option) (StorageBuilder, error) {
 	options := basicB.ApplyOptions(opts...)
 	// TODO lots of repeated code + if logic, clean up below
-	if flags.SpanStorage.Type == flags.CassandraStorageType {
+	if storageType == flags.CassandraStorageType {
 		if options.Cassandra == nil {
 			return nil, errMissingCassandraConfig
 		}
 		// TODO technically span and dependency storage might be separate
-		return newCassandraBuilder(options.Cassandra, options.Logger, options.MetricsFactory), nil
-	} else if flags.SpanStorage.Type == flags.MemoryStorageType {
+		return newCassandraBuilder(options.Cassandra, options.Logger, options.MetricsFactory, dependencyDataFreq), nil
+	} else if storageType == flags.MemoryStorageType {
 		if options.MemoryStore == nil {
 			return nil, errMissingMemoryStore
 		}
 		return newMemoryStoreBuilder(options.MemoryStore), nil
-	} else if flags.SpanStorage.Type == flags.ESStorageType {
+	} else if storageType == flags.ESStorageType {
 		if options.ElasticSearch == nil {
 			return nil, errMissingElasticSearchConfig
 		}

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -21,60 +21,86 @@
 package main
 
 import (
-	"flag"
 	"net/http"
 	"strconv"
 
 	"github.com/gorilla/mux"
-	"go.uber.org/zap"
-
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics/go-kit"
 	"github.com/uber/jaeger-lib/metrics/go-kit/expvar"
 	"github.com/uber/jaeger/cmd/query/app"
+	"go.uber.org/zap"
 
 	basicB "github.com/uber/jaeger/cmd/builder"
+	"github.com/uber/jaeger/cmd/flags"
 	casFlags "github.com/uber/jaeger/cmd/flags/cassandra"
 	"github.com/uber/jaeger/cmd/query/app/builder"
+	"github.com/uber/jaeger/pkg/config"
 	"github.com/uber/jaeger/pkg/recoveryhandler"
 )
 
 func main() {
-	casOptions := casFlags.NewOptions()
-	casOptions.Bind(flag.CommandLine, "cassandra", "cassandra.archive")
-	flag.Parse()
-
 	logger, _ := zap.NewProduction()
-	metricsFactory := xkit.Wrap("jaeger-query", expvar.NewFactory(10))
+	casOptions := casFlags.NewOptions("cassandra", "cassandra.archive")
+	v := viper.New()
 
-	storageBuild, err := builder.NewStorageBuilder(
-		basicB.Options.LoggerOption(logger),
-		basicB.Options.MetricsFactoryOption(metricsFactory),
-		basicB.Options.CassandraOption(casOptions.GetPrimary()),
+	var command = &cobra.Command{
+		Use:   "jaeger-query",
+		Short: "Jaeger query is a service to access tracing data",
+		Long:  `Jaeger query is a service to access tracing data and host UI.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			casOptions.InitFromViper(v)
+			queryOpts := new(builder.QueryOptions).InitFromViper(v)
+			sFlags := new(flags.SharedFlags).InitFromViper(v)
+
+			metricsFactory := xkit.Wrap("jaeger-query", expvar.NewFactory(10))
+
+			storageBuild, err := builder.NewStorageBuilder(
+				sFlags.SpanStorage.Type,
+				sFlags.DependencyStorage.DataFrequency,
+				basicB.Options.LoggerOption(logger),
+				basicB.Options.MetricsFactoryOption(metricsFactory),
+				basicB.Options.CassandraOption(casOptions.GetPrimary()),
+			)
+			if err != nil {
+				logger.Fatal("Failed to init storage builder", zap.Error(err))
+			}
+			spanReader, err := storageBuild.NewSpanReader()
+			if err != nil {
+				logger.Fatal("Failed to create span reader", zap.Error(err))
+			}
+			dependencyReader, err := storageBuild.NewDependencyReader()
+			if err != nil {
+				logger.Fatal("Failed to create dependency reader", zap.Error(err))
+			}
+			rHandler := app.NewAPIHandler(
+				spanReader,
+				dependencyReader,
+				app.HandlerOptions.Prefix(queryOpts.QueryPrefix),
+				app.HandlerOptions.Logger(logger))
+			sHandler := app.NewStaticAssetsHandler(queryOpts.QueryStaticAssets)
+			r := mux.NewRouter()
+			rHandler.RegisterRoutes(r)
+			sHandler.RegisterRoutes(r)
+			portStr := ":" + strconv.Itoa(queryOpts.QueryPort)
+			recoveryHandler := recoveryhandler.NewRecoveryHandler(logger, true)
+			logger.Info("Starting jaeger-query HTTP server", zap.Int("port", queryOpts.QueryPort))
+			if err := http.ListenAndServe(portStr, recoveryHandler(r)); err != nil {
+				logger.Fatal("Could not launch service", zap.Error(err))
+			}
+		},
+	}
+
+	config.AddFlags(
+		v,
+		command,
+		flags.AddFlags,
+		casOptions.AddFlags,
+		builder.AddFlags,
 	)
-	if err != nil {
-		logger.Fatal("Failed to init storage builder", zap.Error(err))
-	}
-	spanReader, err := storageBuild.NewSpanReader()
-	if err != nil {
-		logger.Fatal("Failed to create span reader", zap.Error(err))
-	}
-	dependencyReader, err := storageBuild.NewDependencyReader()
-	if err != nil {
-		logger.Fatal("Failed to create dependency reader", zap.Error(err))
-	}
-	rHandler := app.NewAPIHandler(
-		spanReader,
-		dependencyReader,
-		app.HandlerOptions.Prefix(*builder.QueryPrefix),
-		app.HandlerOptions.Logger(logger))
-	sHandler := app.NewStaticAssetsHandler(*builder.QueryStaticAssets)
-	r := mux.NewRouter()
-	rHandler.RegisterRoutes(r)
-	sHandler.RegisterRoutes(r)
-	portStr := ":" + strconv.Itoa(*builder.QueryPort)
-	recoveryHandler := recoveryhandler.NewRecoveryHandler(logger, true)
-	logger.Info("Starting jaeger-query HTTP server", zap.Int("port", *builder.QueryPort))
-	if err := http.ListenAndServe(portStr, recoveryHandler(r)); err != nil {
-		logger.Fatal("Could not launch service", zap.Error(err))
+
+	if error := command.Execute(); error != nil {
+		logger.Fatal(error.Error())
 	}
 }

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -29,12 +29,12 @@ import (
 	"github.com/spf13/viper"
 	"github.com/uber/jaeger-lib/metrics/go-kit"
 	"github.com/uber/jaeger-lib/metrics/go-kit/expvar"
-	"github.com/uber/jaeger/cmd/query/app"
 	"go.uber.org/zap"
 
 	basicB "github.com/uber/jaeger/cmd/builder"
 	"github.com/uber/jaeger/cmd/flags"
 	casFlags "github.com/uber/jaeger/cmd/flags/cassandra"
+	"github.com/uber/jaeger/cmd/query/app"
 	"github.com/uber/jaeger/cmd/query/app/builder"
 	"github.com/uber/jaeger/pkg/config"
 	"github.com/uber/jaeger/pkg/recoveryhandler"

--- a/crossdock/main.go
+++ b/crossdock/main.go
@@ -125,8 +125,8 @@ func startCollector(logger *zap.Logger) {
 	forkCmd(
 		logger,
 		collectorCmd,
-		"-cassandra.keyspace=jaeger",
-		"-cassandra.servers=cassandra",
+		"--cassandra.keyspace=jaeger",
+		"--cassandra.servers=cassandra",
 	)
 	tChannelHealthCheck(logger, collectorService, collectorHostPort)
 }
@@ -136,8 +136,8 @@ func startQueryService(url string, logger *zap.Logger) services.QueryService {
 	forkCmd(
 		logger,
 		queryCmd,
-		"-cassandra.keyspace=jaeger",
-		"-cassandra.servers=cassandra",
+		"--cassandra.keyspace=jaeger",
+		"--cassandra.servers=cassandra",
 	)
 	if url == "" {
 		url = queryServiceURL

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,7 +38,7 @@ across several collectors ([issue 213](https://github.com/uber/jaeger/issues/213
 
 Many instances of **jaeger-collector** can be run in parallel.
 Collectors require almost no configuration, except for the location of Cassandra cluster,
-via `-cassandra.keyspace` and `-cassandra.servers` options. To see all command line options run
+via `--cassandra.keyspace` and `--cassandra.servers` options. To see all command line options run
 
 ```
 go run ./cmd/collector/main.go -h
@@ -98,3 +98,9 @@ that will include aggregating data to present service dependency diagram.
 
 
 [cqlsh]: http://cassandra.apache.org/doc/latest/tools/cqlsh.html
+
+## Configuration
+All binaries accepts command line properties and environmental variables which are managed by
+by [viper](https://github.com/spf13/viper) and [cobra](https://github.com/spf13/cobra).
+The names of environmental properties are capital letters and characters `-` and `.` are replaced with `_`.
+To list all configuration properties call `jaeger-binary -h`.

--- a/pkg/cassandra/config/config.go
+++ b/pkg/cassandra/config/config.go
@@ -68,8 +68,14 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	}
 }
 
+// SessionBuilder creates new cassandra.Session
+type SessionBuilder interface {
+	NewSession() (cassandra.Session, error)
+}
+
 // NewSession creates a new Cassandra session
 func (c *Configuration) NewSession() (cassandra.Session, error) {
+	c.ProtoVersion = 4
 	cluster := c.NewCluster()
 	session, err := cluster.CreateSession()
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,41 +18,47 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package builder
+package config
 
 import (
 	"flag"
+	"strings"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-const (
-	queryPort        = "query.port"
-	queryPrefix      = "query.prefix"
-	queryStaticFiles = "query.static-files"
-)
+// Viperize creates new Viper and command add passes flags to command
+// Viper is initialized with flags from command and configured to accept flags as environmental variables.
+// Characters `.-` in environmental variables are changed to `_`
+func Viperize(inits ...func(*flag.FlagSet)) (*viper.Viper, *cobra.Command) {
+	command := &cobra.Command{}
+	flagSet := new(flag.FlagSet)
+	for i := range inits {
+		inits[i](flagSet)
+	}
+	command.PersistentFlags().AddGoFlagSet(flagSet)
 
-// QueryOptions holds configuration for query
-type QueryOptions struct {
-	// QueryPort is the port that the query service listens in on
-	QueryPort int
-	// QueryPrefix is the prefix of the query service api
-	QueryPrefix string
-	// QueryStaticAssets is the path for the static assets for the UI (https://github.com/uber/jaeger-ui)
-	QueryStaticAssets string
+	v := viper.New()
+	configureViper(v)
+	v.BindPFlags(command.PersistentFlags())
+	return v, command
 }
 
-// AddFlags adds flags for QueryOptions
-func AddFlags(flagSet *flag.FlagSet) {
-	flagSet.Int(queryPort, 16686, "The port for the query service")
-	flagSet.String(queryPrefix, "api", "The prefix for the url of the query service")
-	flagSet.String(queryStaticFiles, "jaeger-ui-build/build/", "The path for the static assets for the UI")
+// AddFlags adds flags to command and viper and configures
+func AddFlags(v *viper.Viper, command *cobra.Command, inits ...func(*flag.FlagSet)) (*viper.Viper, *cobra.Command) {
+	flagSet := new(flag.FlagSet)
+	for i := range inits {
+		inits[i](flagSet)
+	}
+	command.PersistentFlags().AddGoFlagSet(flagSet)
+
+	configureViper(v)
+	v.BindPFlags(command.PersistentFlags())
+	return v, command
 }
 
-// InitFromViper initializes QueryOptions with properties from viper
-func (qOpts *QueryOptions) InitFromViper(v *viper.Viper) *QueryOptions {
-	qOpts.QueryPort = v.GetInt(queryPort)
-	qOpts.QueryPrefix = v.GetString(queryPrefix)
-	qOpts.QueryStaticAssets = v.GetString(queryStaticFiles)
-	return qOpts
+func configureViper(v *viper.Viper) {
+	v.AutomaticEnv()
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 }

--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -40,6 +40,13 @@ type Configuration struct {
 	NumReplicas int64         `yaml:"replicas"`
 }
 
+// ClientBuilder creates new es.Client
+type ClientBuilder interface {
+	NewClient() (es.Client, error)
+	GetNumShards() int64
+	GetNumReplicas() int64
+}
+
 // NewClient creates a new ElasticSearch client
 func (c *Configuration) NewClient() (es.Client, error) {
 	if len(c.Servers) < 1 {
@@ -50,6 +57,16 @@ func (c *Configuration) NewClient() (es.Client, error) {
 		return nil, err
 	}
 	return es.WrapESClient(rawClient), nil
+}
+
+// GetNumShards returns number of shards from Configuration
+func (c *Configuration) GetNumShards() int64 {
+	return c.NumShards
+}
+
+// GetNumReplicas returns number of replicas from Configuration
+func (c *Configuration) GetNumReplicas() int64 {
+	return c.NumReplicas
 }
 
 // GetConfigs wraps the configs to feed to the ElasticSearch client init


### PR DESCRIPTION
@yurishkuro I have opened this as a final version of #235 . Let's keep it simple stick to the current behavior and do refactoring in separate PRs. After this is merged I will submit PRs to address: 
* #296 
* `span_handler_builder` init functions to not return func, but immediately create a connection to C*/elastic