### PR TITLE
Remove default cassandra ProtoVersion

### DIFF
--- a/pkg/cassandra/config/config.go
+++ b/pkg/cassandra/config/config.go
@@ -75,7 +75,6 @@ type SessionBuilder interface {
 
 // NewSession creates a new Cassandra session
 func (c *Configuration) NewSession() (cassandra.Session, error) {
-	c.ProtoVersion = 4
 	cluster := c.NewCluster()
 	session, err := cluster.CreateSession()
 	if err != nil {


### PR DESCRIPTION
We currently hard code the version to 4; this doesn't seem necessary given default protoVersion is set on the primary namespace and gocql also discovers the best protoVersion for the current session if protoVersion is not set.

As a side note we run cassandra 2 internally for "reasons" and this prevents it.