### PR TITLE
Change ElasticSearch replicas default value

### DIFF
--- a/cmd/flags/es/options.go
+++ b/cmd/flags/es/options.go
@@ -70,7 +70,7 @@ func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 				Sniffer:     false,
 				MaxSpanAge:  72 * time.Hour,
 				NumShards:   5,
-				NumReplicas: 2,
+				NumReplicas: 1,
 			},
 			servers:   "http://127.0.0.1:9200",
 			namespace: primaryNamespace,

--- a/cmd/flags/es/options_test.go
+++ b/cmd/flags/es/options_test.go
@@ -36,7 +36,7 @@ func TestOptions(t *testing.T) {
 	assert.Empty(t, primary.Password)
 	assert.NotEmpty(t, primary.Servers)
 	assert.Equal(t, int64(5), primary.NumShards)
-	assert.Equal(t, int64(2), primary.NumReplicas)
+	assert.Equal(t, int64(1), primary.NumReplicas)
 	assert.Equal(t, 72*time.Hour, primary.MaxSpanAge)
 	assert.False(t, primary.Sniffer)
 

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -43,7 +43,7 @@ const (
 	serviceType = "service"
 
 	defaultNumShards   = 5
-	defaultNumReplicas = 2
+	defaultNumReplicas = 1
 )
 
 type spanWriterMetrics struct {

--- a/plugin/storage/es/spanstore/writer_test.go
+++ b/plugin/storage/es/spanstore/writer_test.go
@@ -327,7 +327,7 @@ func TestFixMapping(t *testing.T) {
 		expectedMapping := `{
 		   "settings":{
 		      "index.number_of_shards": 5,
-      		      "index.number_of_replicas": 2,
+      		      "index.number_of_replicas": 1,
 		      "index.mapping.nested_fields.limit":50,
 		      "index.requests.cache.enable":true,
 		      "index.mapper.dynamic":false


### PR DESCRIPTION
the default value of replicas is 1, not 2; passing in 1 as the number of replicas means 1 primary + 1 replica, so 2 in total.
https://www.elastic.co/guide/en/elasticsearch/guide/current/replica-shards.html