### PR TITLE
Add adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,15 @@
+* Atlassian
+* Base CRM
+* Booking.com
+* Circonus
+* Massachusetts Open Cloud
+* Nets
+* Orange
+* Squarespace
+* Stagemonitor
+* Red Hat 
+  * https://github.com/jaegertracing/jaeger-openshift
+  * http://www.hawkular.org/blog.html 
+* UBER
+  * https://eng.uber.com/distributed-tracing/
+* Zenly

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Reach project contributors via these channels:
  * [Gitter chat room](https://gitter.im/jaegertracing/Lobby)
  * [Github issues](https://github.com/uber/jaeger/issues)
 
+## Adopters
+
+Jaeger is [used in production](./ADOPTERS.md) by organizations such as Atlassian, Orange, Red Hat and Uber.
+
+If you use Jaeger in production, please consider adding yourself to our [ADOPTERS.md](./ADOPTERS.md)
+
 ## License
 
 [The MIT License](./LICENSE).


### PR DESCRIPTION
Add an ADOPTERS.md to track production usage of Jaeger. It's also easier for potential adopters to add themselves to the list. Also update the README with this information.