### PR TITLE
Zipkin span start time and duration sanitizer

### DIFF
--- a/cmd/collector/app/builder/span_handler_builder.go
+++ b/cmd/collector/app/builder/span_handler_builder.go
@@ -126,6 +126,7 @@ func (spanHb *SpanHandlerBuilder) BuildHandlers() (app.ZipkinSpansHandler, app.J
 
 	zSanitizer := zs.NewChainedSanitizer(
 		zs.NewSpanDurationSanitizer(spanHb.logger),
+		zs.NewSpanStartTimeSanitizer(),
 		zs.NewParentIDSanitizer(spanHb.logger),
 		zs.NewErrorTagSanitizer(),
 	)

--- a/cmd/collector/app/sanitizer/zipkin/span_sanitizer.go
+++ b/cmd/collector/app/sanitizer/zipkin/span_sanitizer.go
@@ -82,7 +82,7 @@ type spanDurationSanitizer struct {
 
 func (s *spanDurationSanitizer) Sanitize(span *zc.Span) *zc.Span {
 	if span.Duration == nil {
-		var duration int64 = defaultDuration
+		duration := defaultDuration
 		if len(span.Annotations) >= 2 {
 			// Prefer RPC one-way (cs -> sr) vs arbitrary annotations.
 			first := span.Annotations[0].Timestamp

--- a/cmd/collector/app/sanitizer/zipkin/span_sanitizer_test.go
+++ b/cmd/collector/app/sanitizer/zipkin/span_sanitizer_test.go
@@ -69,10 +69,9 @@ func TestSpanDurationSanitizer(t *testing.T) {
 	actual = sanitizer.Sanitize(nilDurationSpan)
 	assert.Equal(t, int64(1), *actual.Duration)
 
-
 	span = &zipkincore.Span{
 		Annotations: []*zipkincore.Annotation{
-			{Value: zipkincore.CLIENT_SEND,Timestamp: 10},
+			{Value: zipkincore.CLIENT_SEND, Timestamp: 10},
 			{Value: zipkincore.CLIENT_RECV, Timestamp: 30},
 		},
 	}
@@ -81,8 +80,8 @@ func TestSpanDurationSanitizer(t *testing.T) {
 
 	span = &zipkincore.Span{
 		Annotations: []*zipkincore.Annotation{
-			{Value: "first",Timestamp: 100},
-			{Value: zipkincore.CLIENT_SEND,Timestamp: 10},
+			{Value: "first", Timestamp: 100},
+			{Value: zipkincore.CLIENT_SEND, Timestamp: 10},
 			{Value: zipkincore.CLIENT_RECV, Timestamp: 30},
 			{Value: "last", Timestamp: 300},
 		},
@@ -182,7 +181,7 @@ func TestSpanStartTimeSanitizer(t *testing.T) {
 	span := &zipkincore.Span{
 		Timestamp: &helper,
 		Annotations: []*zipkincore.Annotation{
-			{Value: zipkincore.CLIENT_SEND,Timestamp: 10},
+			{Value: zipkincore.CLIENT_SEND, Timestamp: 10},
 			{Value: zipkincore.SERVER_RECV, Timestamp: 20},
 		},
 	}
@@ -191,7 +190,7 @@ func TestSpanStartTimeSanitizer(t *testing.T) {
 
 	span = &zipkincore.Span{
 		Annotations: []*zipkincore.Annotation{
-			{Value: zipkincore.CLIENT_SEND,Timestamp: 10},
+			{Value: zipkincore.CLIENT_SEND, Timestamp: 10},
 			{Value: zipkincore.SERVER_RECV, Timestamp: 20},
 		},
 	}
@@ -199,7 +198,7 @@ func TestSpanStartTimeSanitizer(t *testing.T) {
 	assert.Equal(t, int64(10), *sanitized.Timestamp)
 	span = &zipkincore.Span{
 		Annotations: []*zipkincore.Annotation{
-			{Value: zipkincore.SERVER_SEND,Timestamp: 10},
+			{Value: zipkincore.SERVER_SEND, Timestamp: 10},
 			{Value: zipkincore.SERVER_RECV, Timestamp: 20},
 		},
 	}

--- a/cmd/collector/app/span_handler.go
+++ b/cmd/collector/app/span_handler.go
@@ -30,7 +30,6 @@ import (
 	"github.com/uber/jaeger/model/converter/thrift/zipkin"
 	"github.com/uber/jaeger/thrift-gen/jaeger"
 	"github.com/uber/jaeger/thrift-gen/zipkincore"
-	zc "github.com/uber/jaeger/thrift-gen/zipkincore"
 )
 
 const (
@@ -45,7 +44,7 @@ const (
 // ZipkinSpansHandler consumes and handles zipkin spans
 type ZipkinSpansHandler interface {
 	// SubmitZipkinBatch records a batch of spans in Zipkin Thrift format
-	SubmitZipkinBatch(ctx thrift.Context, spans []*zc.Span) ([]*zc.Response, error)
+	SubmitZipkinBatch(ctx thrift.Context, spans []*zipkincore.Span) ([]*zipkincore.Response, error)
 }
 
 // JaegerBatchesHandler consumes and handles Jaeger batches


### PR DESCRIPTION
Similar to: https://github.com/openzipkin/zipkin/blob/master/zipkin/src/main/java/zipkin/internal/ApplyTimestampAndDuration.java

This is required for follow-up PR with zipkin JSON encoding.