### PR TITLE
Replaced base Docker images for agent/collector/query

### DIFF
--- a/cmd/agent/Dockerfile
+++ b/cmd/agent/Dockerfile
@@ -1,6 +1,5 @@
-FROM centos:7
+FROM scratch
+
 EXPOSE 5775/udp 6831/udp 6832/udp 5778
-
 COPY agent-linux /go/bin/
-
 CMD ["/go/bin/agent-linux"]

--- a/cmd/collector/Dockerfile
+++ b/cmd/collector/Dockerfile
@@ -1,6 +1,5 @@
-FROM centos:7
+FROM scratch
+
 EXPOSE 14267
-
 COPY collector-linux /go/bin/
-
 CMD ["/go/bin/collector-linux"]

--- a/cmd/query/Dockerfile
+++ b/cmd/query/Dockerfile
@@ -1,7 +1,6 @@
-FROM centos:7
-EXPOSE 16686
+FROM scratch
 
+EXPOSE 16686
 COPY query-linux /go/bin/
 ADD jaeger-ui-build /go/jaeger-ui/
-
 CMD ["/go/bin/query-linux", "--query.static-files=/go/jaeger-ui/"]


### PR DESCRIPTION
Tested this with the OpenShift templates and they work as expected. No changes are necessary to the existing OpenShift/Kubernetes templates, so, I don't expect it to break any other client.