### PR TITLE
Fix issue with number_of_replicas getting set to 1 instead of 0 during ES index creation

### DIFF
--- a/pkg/es/config/config.go
+++ b/pkg/es/config/config.go
@@ -77,9 +77,6 @@ func (c *Configuration) ApplyDefaults(source *Configuration) {
 	if c.NumShards == 0 {
 		c.NumShards = source.NumShards
 	}
-	if c.NumReplicas == 0 {
-		c.NumReplicas = source.NumReplicas
-	}
 }
 
 // GetNumShards returns number of shards from Configuration

--- a/plugin/storage/es/spanstore/writer.go
+++ b/plugin/storage/es/spanstore/writer.go
@@ -83,9 +83,6 @@ func NewSpanWriter(
 	if numShards == 0 {
 		numShards = defaultNumShards
 	}
-	if numReplicas == 0 {
-		numReplicas = defaultNumReplicas
-	}
 	// TODO: Configurable TTL
 	serviceOperationStorage := NewServiceOperationStorage(ctx, client, metricsFactory, logger, time.Hour*12)
 	return &SpanWriter{


### PR DESCRIPTION
Make sure when `--es.num-replicas` argument is passed value of 0, we don't set
incorrectly set number_of_replicas=1 as ES index property