### PR TITLE
cassandra/spanstore: speed up query by service name

### DIFF
--- a/plugin/storage/cassandra/spanstore/reader.go
+++ b/plugin/storage/cassandra/spanstore/reader.go
@@ -50,7 +50,6 @@ const (
 		SELECT trace_id
 		FROM service_name_index
 		WHERE bucket IN ` + bucketRange + ` AND service_name = ? AND start_time > ? AND start_time < ?
-		ORDER BY start_time DESC
 		LIMIT ?`
 	queryByServiceAndOperationName = `
 		SELECT trace_id


### PR DESCRIPTION
The service_name_index table is orded on disk by start_time DESC so
reads by full partition key will return ordered by start_time. Removing
the order by in the query to list spans significantly improves span
listing performance, observed going from >20s per query to <500ms.