### PR TITLE
use `http-status` as log field name when set new HTTP status for the health check

### DIFF
--- a/pkg/healthcheck/handler.go
+++ b/pkg/healthcheck/handler.go
@@ -85,7 +85,7 @@ func (s *State) Ready() {
 // Set a new HTTP status for the health check
 func (s *State) Set(state int) {
 	s.state = state
-	s.logger.Info("Health Check state change", zap.Int("http-port", s.state))
+	s.logger.Info("Health Check state change", zap.Int("http-status", s.state))
 }
 
 // Get the current status code for this health check


### PR DESCRIPTION
log field name `http-port` for new HTTP status is misleading, change to `http-status`